### PR TITLE
Update to version v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2023-12-18
+
+### Added
+
+-   Support for Amazon Titan Text Lite, Anthropic Claude v2.1, Cohere Command models, and Meta Llama 2 Chat models
+
+### Changed
+
+-   Increase the cap on the max number of docs retrieved in the Amazon Kendra retriever (for RAG use cases) from 5 to 100, to match the API limit
+
+### Fixed
+
+-   Fix typo in UI deployment instructions (#26)
+-   Fix bug causing failures with dictionary type advanced model parameters
+-   Fixed bug causing erroneous error messages to appear to user in long running conversations
+
+### Security
+
+-   Updated Python and Node package versions to resolve security vulnerabilities
+
 ## [1.1.1] - 2023-11-16
 
 ### Fixed

--- a/source/infrastructure/cdk.json
+++ b/source/infrastructure/cdk.json
@@ -28,7 +28,7 @@
     "@aws-cdk/core:target-partitions": ["aws", "aws-cn", "aws-us-gov"],
     "solution_id": "SO0276",
     "solution_name": "generative-ai-application-builder-on-aws",
-    "solution_version": "v1.1.0",
+    "solution_version": "v1.2.0",
     "app_registry_name": "GAAB",
     "application_type": "AWS-Solutions",
     "application_trademark_name": "Generative AI Application Builder on AWS"

--- a/source/infrastructure/lib/metrics/deployment-platform-dashboard.ts
+++ b/source/infrastructure/lib/metrics/deployment-platform-dashboard.ts
@@ -16,7 +16,7 @@ import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import { Construct } from 'constructs';
 import { CustomDashboard, CustomDashboardProps } from './custom-dashboard';
 import { CloudWatchNamespace, CloudWatchMetrics } from '../utils/constants';
-import { SERVICE_NAME } from '../../lib/utils/constants'
+import { SERVICE_NAME } from '../../lib/utils/constants';
 
 /**
  * This construct creates a custom Dashboard in Amazon CloudWatch and adds widgets and defines metrics. It defines
@@ -168,7 +168,7 @@ export class DeploymentPlatformDashboard extends CustomDashboard {
                         statistic: cloudwatch.Stats.SAMPLE_COUNT,
                         period: cdk.Duration.hours(1),
                         dimensionsMap: {
-                            service: SERVICE_NAME,
+                            service: SERVICE_NAME
                         },
                         color: cloudwatch.Color.BLUE
                     }),
@@ -178,7 +178,7 @@ export class DeploymentPlatformDashboard extends CustomDashboard {
                         label: CloudWatchMetrics.UC_INITIATION_FAILURE + 'Count',
                         statistic: cloudwatch.Stats.SAMPLE_COUNT,
                         dimensionsMap: {
-                            service: SERVICE_NAME,
+                            service: SERVICE_NAME
                         },
                         period: cdk.Duration.hours(1),
                         color: cloudwatch.Color.ORANGE
@@ -189,7 +189,7 @@ export class DeploymentPlatformDashboard extends CustomDashboard {
                         label: CloudWatchMetrics.UC_DELETION_SUCCESS + 'Count',
                         statistic: cloudwatch.Stats.SAMPLE_COUNT,
                         dimensionsMap: {
-                            service: SERVICE_NAME,
+                            service: SERVICE_NAME
                         },
                         period: cdk.Duration.hours(1),
                         color: cloudwatch.Color.PURPLE
@@ -200,7 +200,7 @@ export class DeploymentPlatformDashboard extends CustomDashboard {
                         label: CloudWatchMetrics.UC_DELETION_FAILURE + 'Count',
                         statistic: cloudwatch.Stats.SAMPLE_COUNT,
                         dimensionsMap: {
-                            service: SERVICE_NAME,
+                            service: SERVICE_NAME
                         },
                         period: cdk.Duration.hours(1),
                         color: cloudwatch.Color.RED
@@ -211,7 +211,7 @@ export class DeploymentPlatformDashboard extends CustomDashboard {
                         label: CloudWatchMetrics.UC_UPDATE_SUCCESS + 'Count',
                         statistic: cloudwatch.Stats.SAMPLE_COUNT,
                         dimensionsMap: {
-                            service: SERVICE_NAME,
+                            service: SERVICE_NAME
                         },
                         period: cdk.Duration.hours(1),
                         color: cloudwatch.Color.GREEN
@@ -222,7 +222,7 @@ export class DeploymentPlatformDashboard extends CustomDashboard {
                         label: CloudWatchMetrics.UC_UPDATE_FAILURE + 'Count',
                         statistic: cloudwatch.Stats.SAMPLE_COUNT,
                         dimensionsMap: {
-                            service: SERVICE_NAME,
+                            service: SERVICE_NAME
                         },
                         period: cdk.Duration.hours(1),
                         color: cloudwatch.Color.BROWN
@@ -233,7 +233,7 @@ export class DeploymentPlatformDashboard extends CustomDashboard {
                         label: CloudWatchMetrics.UC_DESCRIBE_SUCCESS + 'Count',
                         statistic: cloudwatch.Stats.SAMPLE_COUNT,
                         dimensionsMap: {
-                            service: SERVICE_NAME,
+                            service: SERVICE_NAME
                         },
                         period: cdk.Duration.hours(1),
                         color: cloudwatch.Color.PINK
@@ -244,7 +244,7 @@ export class DeploymentPlatformDashboard extends CustomDashboard {
                         label: CloudWatchMetrics.UC_DESCRIBE_FAILURE + 'Count',
                         statistic: cloudwatch.Stats.SAMPLE_COUNT,
                         dimensionsMap: {
-                            service: SERVICE_NAME,
+                            service: SERVICE_NAME
                         },
                         period: cdk.Duration.hours(1),
                         color: cloudwatch.Color.GREY

--- a/source/infrastructure/lib/use-case-management/management-stack.ts
+++ b/source/infrastructure/lib/use-case-management/management-stack.ts
@@ -659,7 +659,9 @@ const buildCfnDeployRole = (scope: Construct): iam.Role => {
                             'dynamodb:CreateTable',
                             'dynamodb:DeleteTable',
                             'dynamodb:UpdateTimeToLive',
-                            'dynamodb:DescribeTimeToLive'
+                            'dynamodb:DescribeTimeToLive',
+                            'dynamodb:TagResource',
+                            'dynamodb:ListTagsOfResource'
                         ],
                         resources: [
                             `arn:${cdk.Aws.PARTITION}:dynamodb:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:table/*`

--- a/source/infrastructure/lib/utils/app-registry-aspects.ts
+++ b/source/infrastructure/lib/utils/app-registry-aspects.ts
@@ -16,7 +16,7 @@ import * as appreg from '@aws-cdk/aws-servicecatalogappregistry-alpha';
 import * as cdk from 'aws-cdk-lib';
 import { CfnResourceAssociation } from 'aws-cdk-lib/aws-servicecatalogappregistry';
 import { Construct, IConstruct } from 'constructs';
-import * as crypto from 'crypto';
+import { hashValues } from './common-utils';
 
 export interface AppRegistryProps {
     /**
@@ -116,11 +116,15 @@ export class AppRegistry extends Construct implements cdk.IAspect {
                 }
 
                 const nestedStack = node;
-                new CfnResourceAssociation(nestedStack, `ResourceAssociation${crypto.randomUUID()}`, {
-                    application: this.application.get(node.nestedStackParent!.stackId)!.applicationArn,
-                    resource: node.stackId,
-                    resourceType: 'CFN_STACK'
-                });
+                new CfnResourceAssociation(
+                    nestedStack,
+                    `ResourceAssociation${hashValues(cdk.Names.nodeUniqueId(nestedStack.node))}`,
+                    {
+                        application: this.application.get(node.nestedStackParent!.stackId)!.applicationId,
+                        resource: node.stackId,
+                        resourceType: 'CFN_STACK'
+                    }
+                );
 
                 (nestedStack.node.defaultChild as cdk.CfnResource).addDependency(
                     this.application.get(node.nestedStackParent!.stackId)!.node.defaultChild as cdk.CfnResource

--- a/source/infrastructure/lib/utils/common-utils.ts
+++ b/source/infrastructure/lib/utils/common-utils.ts
@@ -17,6 +17,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3_asset from 'aws-cdk-lib/aws-s3-assets';
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as log from 'npmlog';
 import * as path from 'path';
@@ -373,4 +374,13 @@ export function createDefaultLambdaRole(scope: Construct, id: string): iam.Role 
     ]);
 
     return role;
+}
+
+/**
+ * Generates a unique hash identfifer using SHA256 encryption algorithm.
+ */
+export function hashValues(...values: string[]): string {
+    const sha256 = crypto.createHash('sha256');
+    values.forEach((val) => sha256.update(val));
+    return sha256.digest('hex').slice(0, 12);
 }

--- a/source/infrastructure/lib/utils/constants.ts
+++ b/source/infrastructure/lib/utils/constants.ts
@@ -120,18 +120,26 @@ export const enum CHAT_PROVIDERS {
 export const SUPPORTED_CHAT_PROVIDERS = [CHAT_PROVIDERS.HUGGING_FACE, CHAT_PROVIDERS.ANTHROPIC, CHAT_PROVIDERS.BEDROCK];
 
 export const enum BEDROCK_MODEL_FAMILIES {
+    AI21 = 'ai21',
     AMAZON = 'amazon',
     ANTHROPIC = 'anthropic',
-    AI21 = 'ai21'
+    COHERE = 'cohere',
+    META = 'meta'
 }
 
 export const SUPPORTED_BEDROCK_CHAT_MODELS = [
     `${BEDROCK_MODEL_FAMILIES.AI21}.j2-ultra`,
     `${BEDROCK_MODEL_FAMILIES.AI21}.j2-mid`,
     `${BEDROCK_MODEL_FAMILIES.AMAZON}.titan-text-express-v1`,
+    `${BEDROCK_MODEL_FAMILIES.AMAZON}.titan-text-lite-v1`,
     `${BEDROCK_MODEL_FAMILIES.ANTHROPIC}.claude-v1`,
     `${BEDROCK_MODEL_FAMILIES.ANTHROPIC}.claude-v2`,
-    `${BEDROCK_MODEL_FAMILIES.ANTHROPIC}.claude-instant-v1`
+    `${BEDROCK_MODEL_FAMILIES.ANTHROPIC}.claude-v2:1`,
+    `${BEDROCK_MODEL_FAMILIES.ANTHROPIC}.claude-instant-v1`,
+    `${BEDROCK_MODEL_FAMILIES.COHERE}.command-text-v14`,
+    `${BEDROCK_MODEL_FAMILIES.COHERE}.command-light-text-v14`,
+    `${BEDROCK_MODEL_FAMILIES.META}.llama2-13b-chat-v1`,
+    `${BEDROCK_MODEL_FAMILIES.META}.llama2-70b-chat-v1`
 ];
 
 export const DEFAULT_HUGGINGFACE_TEMPERATURE = 1;
@@ -161,6 +169,9 @@ Current conversation:
 
 Human: {input}
 AI:`;
+
+export const DEFAULT_META_CHAT_PROMPT = `[INST] ${DEFAULT_CHAT_PROMPT} [/INST]`;
+export const DEFAULT_META_RAG_PROMPT = `[INST] ${DEFAULT_HUGGINGFACE_RAG_PROMPT} [/INST]`
 
 export const SUPPORTED_ANTHROPIC_CHAT_MODELS = ['claude-instant-1', 'claude-1', 'claude-2'];
 export const DEFAULT_ANTHROPIC_TEMPERATURE = 1;
@@ -199,6 +210,9 @@ Assistant:`;
 export const DEFAULT_BEDROCK_AMAZON_PROMPT = DEFAULT_CHAT_PROMPT;
 export const DEFAULT_BEDROCK_ANTHROPIC_PROMPT = DEFAULT_ANTHROPIC_CHAT_PROMPT;
 export const DEFAULT_BEDROCK_AI21_PROMPT = DEFAULT_CHAT_PROMPT;
+export const DEFAULT_BEDROCK_COHERE_PROMPT = DEFAULT_CHAT_PROMPT;
+export const DEFAULT_BEDROCK_META_PROMPT = DEFAULT_META_CHAT_PROMPT;
+
 export const DEFAULT_BEDROCK_AMAZON_RAG_PROMPT = `Instructions: You are an AI Assistant created to help answer the User's question. You are only to answer the User's question using the provided references. You are not allowed to make things up or use your own knowledge. Only use what is provided between the <references> XML tags.
 
 Here are the only references you can use:
@@ -213,6 +227,28 @@ User: {input}
 Bot:`;
 export const DEFAULT_BEDROCK_ANTHROPIC_RAG_PROMPT = DEFAULT_ANTHROPIC_RAG_PROMPT;
 export const DEFAULT_BEDROCK_AI21_RAG_PROMPT = DEFAULT_HUGGINGFACE_RAG_PROMPT;
+export const DEFAULT_BEDROCK_COHERE_RAG_PROMPT = DEFAULT_HUGGINGFACE_RAG_PROMPT;
+export const DEFAULT_BEDROCK_META_RAG_PROMPT = DEFAULT_META_RAG_PROMPT;
+
+export const DEFAULT_BEDROCK_ANTHROPIC_TEMPERATURE = DEFAULT_ANTHROPIC_TEMPERATURE;
+export const MIN_BEDROCK_ANTHROPIC_TEMPERATURE = MIN_ANTHROPIC_TEMPERATURE;
+export const MAX_BEDROCK_ANTHROPIC_TEMPERATURE = MAX_ANTHROPIC_TEMPERATURE;
+
+export const DEFAULT_BEDROCK_AMAZON_TEMPERATURE = 0.5;
+export const MIN_BEDROCK_AMAZON_TEMPERATURE = 0;
+export const MAX_BEDROCK_AMAZON_TEMPERATURE = 1;
+
+export const DEFAULT_BEDROCK_AI21_TEMPERATURE = 1;
+export const MIN_BEDROCK_AI21_TEMPERATURE = 0;
+export const MAX_BEDROCK_AI21_TEMPERATURE = 1;
+
+export const DEFAULT_BEDROCK_COHERE_TEMPERATURE = 0.75;
+export const MIN_BEDROCK_COHERE_TEMPERATURE = 0;
+export const MAX_BEDROCK_COHERE_TEMPERATURE = 1;
+
+export const DEFAULT_BEDROCK_META_TEMPERATURE = 0.5;
+export const MIN_BEDROCK_META_TEMPERATURE = 0;
+export const MAX_BEDROCK_META_TEMPERATURE = 1;
 
 export const KENDRA_EDITIONS = ['DEVELOPER_EDITION', 'ENTERPRISE_EDITION'];
 export const DEFAULT_KENDRA_EDITION = 'DEVELOPER_EDITION';
@@ -247,7 +283,7 @@ export const DEFAULT_KENDRA_STORAGE_CAPACITY_UNITS = 0;
 export const MAX_KENDRA_QUERY_CAPACITY_UNITS = 1;
 export const MAX_KENDRA_STORAGE_CAPACITY_UNITS = 5;
 export const DEFAULT_KENDRA_NUMBER_OF_DOCS = 2;
-export const MAX_KENDRA_NUMBER_OF_DOCS = 5;
+export const MAX_KENDRA_NUMBER_OF_DOCS = 100;
 export const MIN_KENDRA_NUMBER_OF_DOCS = 1;
 export const MODEL_PARAM_TYPES = ['string', 'integer', 'float', 'boolean', 'list', 'dictionary'];
 
@@ -292,26 +328,40 @@ export const additionalDeploymentPlatformConfigValues = {
             SupportedModels: SUPPORTED_BEDROCK_CHAT_MODELS,
             AllowsStreaming: true,
             ModelFamilyParams: {
+                [BEDROCK_MODEL_FAMILIES.AI21]: {
+                    ChatPromptTemplate: DEFAULT_BEDROCK_AI21_PROMPT,
+                    RAGPromptTemplate: DEFAULT_BEDROCK_AI21_RAG_PROMPT,
+                    DefaultTemperature: DEFAULT_BEDROCK_AI21_TEMPERATURE,
+                    MinTemperature: MIN_BEDROCK_AI21_TEMPERATURE,
+                    MaxTemperature: MAX_BEDROCK_AI21_TEMPERATURE
+                },
                 [BEDROCK_MODEL_FAMILIES.AMAZON]: {
                     ChatPromptTemplate: DEFAULT_BEDROCK_AMAZON_PROMPT,
                     RAGPromptTemplate: DEFAULT_BEDROCK_AMAZON_RAG_PROMPT,
-                    DefaultTemperature: DEFAULT_ANTHROPIC_TEMPERATURE,
-                    MinTemperature: MIN_ANTHROPIC_TEMPERATURE,
-                    MaxTemperature: MAX_ANTHROPIC_TEMPERATURE
+                    DefaultTemperature: DEFAULT_BEDROCK_AMAZON_TEMPERATURE,
+                    MinTemperature: MIN_BEDROCK_AMAZON_TEMPERATURE,
+                    MaxTemperature: MAX_BEDROCK_AMAZON_TEMPERATURE
                 },
                 [BEDROCK_MODEL_FAMILIES.ANTHROPIC]: {
                     ChatPromptTemplate: DEFAULT_BEDROCK_ANTHROPIC_PROMPT,
                     RAGPromptTemplate: DEFAULT_BEDROCK_ANTHROPIC_RAG_PROMPT,
-                    DefaultTemperature: DEFAULT_ANTHROPIC_TEMPERATURE,
-                    MinTemperature: MIN_ANTHROPIC_TEMPERATURE,
-                    MaxTemperature: MAX_ANTHROPIC_TEMPERATURE
+                    DefaultTemperature: DEFAULT_BEDROCK_ANTHROPIC_TEMPERATURE,
+                    MinTemperature: MIN_BEDROCK_ANTHROPIC_TEMPERATURE,
+                    MaxTemperature: MAX_BEDROCK_ANTHROPIC_TEMPERATURE
                 },
-                [BEDROCK_MODEL_FAMILIES.AI21]: {
-                    ChatPromptTemplate: DEFAULT_BEDROCK_AI21_PROMPT,
-                    RAGPromptTemplate: DEFAULT_BEDROCK_AI21_RAG_PROMPT,
-                    DefaultTemperature: DEFAULT_ANTHROPIC_TEMPERATURE,
-                    MinTemperature: MIN_ANTHROPIC_TEMPERATURE,
-                    MaxTemperature: MAX_ANTHROPIC_TEMPERATURE
+                [BEDROCK_MODEL_FAMILIES.COHERE]: {
+                    ChatPromptTemplate: DEFAULT_BEDROCK_COHERE_PROMPT,
+                    RAGPromptTemplate: DEFAULT_BEDROCK_COHERE_RAG_PROMPT,
+                    DefaultTemperature: DEFAULT_BEDROCK_COHERE_TEMPERATURE,
+                    MinTemperature: MIN_BEDROCK_COHERE_TEMPERATURE,
+                    MaxTemperature: MAX_BEDROCK_COHERE_TEMPERATURE
+                },
+                [BEDROCK_MODEL_FAMILIES.META]: {
+                    ChatPromptTemplate: DEFAULT_BEDROCK_META_PROMPT,
+                    RAGPromptTemplate: DEFAULT_BEDROCK_META_RAG_PROMPT,
+                    DefaultTemperature: DEFAULT_BEDROCK_META_TEMPERATURE,
+                    MinTemperature: MIN_BEDROCK_META_TEMPERATURE,
+                    MaxTemperature: MAX_BEDROCK_META_TEMPERATURE
                 }
             }
         }

--- a/source/infrastructure/lib/utils/custom-infra-setup.ts
+++ b/source/infrastructure/lib/utils/custom-infra-setup.ts
@@ -165,6 +165,6 @@ export class CustomInfraSetup extends Construct {
                 reason: 'The wildcard permission is required to publish events for x-ray insights',
                 appliesTo: ['Resource::*']
             }
-        ]);        
+        ]);
     }
 }

--- a/source/infrastructure/package-lock.json
+++ b/source/infrastructure/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gen-ai-app-builder-on-aws-infrastructure",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gen-ai-app-builder-on-aws-infrastructure",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.99.1-alpha.0",

--- a/source/infrastructure/package.json
+++ b/source/infrastructure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gen-ai-app-builder-on-aws-infrastructure",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "bin": {
     "infrastructure": "bin/gen-ai-app-builder.js"
   },

--- a/source/infrastructure/test/mock-lambda-func/node-lambda/package-lock.json
+++ b/source/infrastructure/test/mock-lambda-func/node-lambda/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-lambda",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-lambda",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0"
     }
   }

--- a/source/infrastructure/test/mock-lambda-func/node-lambda/package.json
+++ b/source/infrastructure/test/mock-lambda-func/node-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lambda",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A mock lambda implementation for CDK infrastructure unit",
   "main": "index.js",
   "scripts": {

--- a/source/infrastructure/test/mock-lambda-func/typescript-lambda/package-lock.json
+++ b/source/infrastructure/test/mock-lambda-func/typescript-lambda/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mock-typescript-lambda",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mock-typescript-lambda",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/aws-lambda": "8.10.115",

--- a/source/infrastructure/test/mock-lambda-func/typescript-lambda/package.json
+++ b/source/infrastructure/test/mock-lambda-func/typescript-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-typescript-lambda",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A mock lambda implementation for CDK infrastructure unit",
   "main": "index.ts",
   "scripts": {

--- a/source/infrastructure/test/mock-ui/package-lock.json
+++ b/source/infrastructure/test/mock-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mock-react-app",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mock-react-app",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "^18.2.0"

--- a/source/infrastructure/test/mock-ui/package.json
+++ b/source/infrastructure/test/mock-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-react-app",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Mock Reactjs app used for unit testing constructs",
   "main": "index.js",
   "scripts": {

--- a/source/infrastructure/test/use-case-management/management-stack.test.ts
+++ b/source/infrastructure/test/use-case-management/management-stack.test.ts
@@ -971,7 +971,9 @@ describe('When creating a use case management Stack', () => {
                                     'dynamodb:CreateTable',
                                     'dynamodb:DeleteTable',
                                     'dynamodb:UpdateTimeToLive',
-                                    'dynamodb:DescribeTimeToLive'
+                                    'dynamodb:DescribeTimeToLive',
+                                    'dynamodb:TagResource',
+                                    'dynamodb:ListTagsOfResource'
                                 ],
                                 Condition: {
                                     'ForAllValues:StringEquals': {

--- a/source/lambda/chat/anthropic_handler.py
+++ b/source/lambda/chat/anthropic_handler.py
@@ -20,12 +20,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from clients.anthropic_client import AnthropicClient
 from shared.callbacks.websocket_error_handler import WebsocketErrorHandler
 from shared.callbacks.websocket_handler import WebsocketHandler
-from utils.constants import (
-    DEFAULT_ANTHROPIC_RAG_ENABLED_MODE,
-    RAG_ENABLED_ENV_VAR,
-    TRACE_ID_ENV_VAR,
-    USER_ID_EVENT_KEY,
-)
+from utils.constants import DEFAULT_ANTHROPIC_RAG_ENABLED_MODE, RAG_ENABLED_ENV_VAR, TRACE_ID_ENV_VAR, USER_ID_EVENT_KEY
 from utils.enum_types import CloudWatchNamespaces
 from utils.handler_response_formatter import format_response
 
@@ -42,11 +37,11 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> Dict:
     :param context (LambdaContext): AWS Lambda Context
     :return: the generated response from the chatbot
     """
-    anthropic_client = AnthropicClient(
-        connection_id=event["requestContext"]["connectionId"],
-        rag_enabled=os.getenv(RAG_ENABLED_ENV_VAR, DEFAULT_ANTHROPIC_RAG_ENABLED_MODE),
-    )
     try:
+        anthropic_client = AnthropicClient(
+            connection_id=event["requestContext"]["connectionId"],
+            rag_enabled=os.getenv(RAG_ENABLED_ENV_VAR, DEFAULT_ANTHROPIC_RAG_ENABLED_MODE),
+        )
         anthropic_client.check_env()
         event_body = anthropic_client.check_event(event)
 

--- a/source/lambda/chat/bedrock_handler.py
+++ b/source/lambda/chat/bedrock_handler.py
@@ -37,11 +37,11 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> Dict:
     :param context (LambdaContext): AWS Lambda Context
     :return: the generated response from the chatbot
     """
-    bedrock_client = BedrockClient(
-        connection_id=event["requestContext"]["connectionId"],
-        rag_enabled=os.getenv(RAG_ENABLED_ENV_VAR, DEFAULT_BEDROCK_RAG_ENABLED_MODE),
-    )
     try:
+        bedrock_client = BedrockClient(
+            connection_id=event["requestContext"]["connectionId"],
+            rag_enabled=os.getenv(RAG_ENABLED_ENV_VAR, DEFAULT_BEDROCK_RAG_ENABLED_MODE),
+        )
         bedrock_client.check_env()
         event_body = bedrock_client.check_event(event)
 

--- a/source/lambda/chat/huggingface_handler.py
+++ b/source/lambda/chat/huggingface_handler.py
@@ -42,12 +42,12 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> Dict:
     :param context (LambdaContext): AWS Lambda Context
     :return: the generated response from the chatbot
     """
-    huggingface_client = HuggingFaceClient(
-        connection_id=event["requestContext"]["connectionId"],
-        rag_enabled=os.getenv(RAG_ENABLED_ENV_VAR, DEFAULT_HUGGINGFACE_RAG_ENABLED_MODE),
-    )
 
     try:
+        huggingface_client = HuggingFaceClient(
+            connection_id=event["requestContext"]["connectionId"],
+            rag_enabled=os.getenv(RAG_ENABLED_ENV_VAR, DEFAULT_HUGGINGFACE_RAG_ENABLED_MODE),
+        )
         huggingface_client.check_env()
         event_body = huggingface_client.check_event(event)
         huggingface_chat = huggingface_client.get_model(

--- a/source/lambda/chat/llm_models/bedrock.py
+++ b/source/lambda/chat/llm_models/bedrock.py
@@ -204,6 +204,7 @@ class BedrockLLM(BaseLangChainModel):
         """
         sanitized_model_params = super().get_clean_model_params(model_params)
         bedrock_adapter = BedrockAdapterFactory().get_bedrock_adapter(self.model_family)
+        sanitized_model_params["temperature"] = float(self.temperature)
 
         try:
             bedrock_llm_params_dict = bedrock_adapter(**sanitized_model_params).get_params_as_dict()
@@ -217,8 +218,10 @@ class BedrockLLM(BaseLangChainModel):
             raise LLMBuildError(error_message)
 
         stop_sequence_keys = ["stop_sequences", "stopSequences"]
+        self.stop_sequences = []
         for stop in stop_sequence_keys:
             if stop in bedrock_llm_params_dict:
                 self.stop_sequences = bedrock_llm_params_dict[stop]
+                break
 
         return bedrock_llm_params_dict

--- a/source/lambda/chat/llm_models/factories/bedrock_adapter_factory.py
+++ b/source/lambda/chat/llm_models/factories/bedrock_adapter_factory.py
@@ -16,7 +16,10 @@ from aws_lambda_powertools import Logger
 from llm_models.models.bedrock_ai21_params import BedrockAI21LLMParams
 from llm_models.models.bedrock_anthropic_params import BedrockAnthropicLLMParams
 from llm_models.models.bedrock_llm_params import BedrockLLMParams
-from llm_models.models.bedrock_titan_params import BedrockTitanLLMParams
+from llm_models.models.bedrock_amazon_params import BedrockAmazonLLMParams
+from llm_models.models.bedrock_meta_params import BedrockMetaLLMParams
+from llm_models.models.bedrock_cohere_params import BedrockCohereLLMParams
+
 from utils.enum_types import BedrockModelProviders
 
 logger = Logger(utc=True)
@@ -32,7 +35,9 @@ class BedrockAdapterFactory:
         self.model_map = {
             BedrockModelProviders.ANTHROPIC.value: BedrockAnthropicLLMParams,
             BedrockModelProviders.AI21.value: BedrockAI21LLMParams,
-            BedrockModelProviders.AMAZON.value: BedrockTitanLLMParams,
+            BedrockModelProviders.AMAZON.value: BedrockAmazonLLMParams,
+            BedrockModelProviders.META.value: BedrockMetaLLMParams,
+            BedrockModelProviders.COHERE.value: BedrockCohereLLMParams,
         }
 
     def get_bedrock_adapter(self, model_family) -> BedrockLLMParams:

--- a/source/lambda/chat/llm_models/models/bedrock_amazon_params.py
+++ b/source/lambda/chat/llm_models/models/bedrock_amazon_params.py
@@ -21,40 +21,38 @@ from utils.enum_types import BedrockModelProviders
 
 
 @dataclass
-class BedrockAI21LLMParams(BedrockLLMParams):
+class BedrockAmazonLLMParams(BedrockLLMParams):
     """
-    Model parameters for the AI21 model available in Bedrock.
-    The class also provides logic to parse and clean model parameters specifically for the Amazon AI21 Bedrock model.
+    Model parameters for the Amazon Titan Bedrock model.
+    The class also provides logic to parse and clean model parameters specifically for the Amazon Titan Bedrock model.
     """
 
-    maxTokens: Optional[int] = None
-    topP: Optional[float] = None
-    countPenalty: Optional[Dict[str, Any]] = None
-    presencePenalty: Optional[Dict[str, Any]] = None
-    frequencyPenalty: Optional[Dict[str, Any]] = None
+    maxTokenCount: Optional[int] = None
     stopSequences: Optional[List[str]] = None
-    temperature: float = DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.AI21.value]
+    topP: Optional[float] = None
+    temperature: Optional[float] = DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.AMAZON.value]
 
     def __post_init__(self):
         """
         Parses model_params to produce clean model parameters per the standards of the an underlying Bedrock model family
-        For example, for Bedrock's AI21 provision,
+        For example, for Amazon Titan,
             if provided with:
                 {
-                    "maxTokens": 250,
+                    "maxTokenCount": 250,
                     "stopSequences": '\nAI:, \nHuman:'
                     "temperature": 0.2,
                     "topP": None
                 }
             the response is:
-                BedrockAI21LLMParams(model_params={'maxTokens': 250, 'stopSequences': ['\nAI:', '\nHuman:'], 'temperature': 0.2})
+                BedrockAmazonLLMParams(model_params={'maxTokenCount': 250, 'stopSequences': ['|', '\nAI:', '\nHuman:'], 'temperature': 0.2})
 
-        Empty keys are dropped from the BedrockAI21LLMParams dataclass object. All model parameters are optional.
+        Empty keys are dropped from the BedrockAmazonLLMParams dataclass object. All model parameters are optional.
         Stop sequences are also set to a default if a default exists for that model provider.
-
         """
         user_stop_sequences = self.stopSequences if self.stopSequences is not None else []
-        self.stopSequences = list(set(BEDROCK_STOP_SEQUENCES[BedrockModelProviders.AI21.value] + user_stop_sequences))
+        self.stopSequences = list(
+            sorted(set(BEDROCK_STOP_SEQUENCES[BedrockModelProviders.AMAZON.value] + user_stop_sequences))
+        )
 
     def get_params_as_dict(self, pop_null=True) -> Dict[str, Any]:
         """

--- a/source/lambda/chat/llm_models/models/bedrock_anthropic_params.py
+++ b/source/lambda/chat/llm_models/models/bedrock_anthropic_params.py
@@ -12,7 +12,7 @@
 #  and limitations under the License.                                                                                #
 ######################################################################################################################
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from llm_models.models.bedrock_llm_params import BedrockLLMParams
@@ -30,8 +30,8 @@ class BedrockAnthropicLLMParams(BedrockLLMParams):
     max_tokens_to_sample: Optional[int] = None
     top_p: Optional[float] = None
     top_k: Optional[float] = None
-    stop_sequences: Optional[List[str]] = field(default_factory=list)
-    temperature: Optional[float] = DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value]
+    stop_sequences: Optional[List[str]] = None
+    temperature: float = DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value]
 
     def __post_init__(self):
         """
@@ -51,19 +51,10 @@ class BedrockAnthropicLLMParams(BedrockLLMParams):
         Temperature is set to model default value if not provided.
         Stop sequences are also set to a default if a default exists for that model provider.
         """
-        user_stop_sequences = self.stop_sequences if self.stop_sequences else []
+        user_stop_sequences = self.stop_sequences if self.stop_sequences is not None else []
         self.stop_sequences = list(
             sorted(set(BEDROCK_STOP_SEQUENCES[BedrockModelProviders.ANTHROPIC.value] + user_stop_sequences))
         )
-
-        self.temperature = (
-            float(self.temperature)
-            if self.temperature is not None
-            else DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value]
-        )
-
-        self.top_p = float(self.top_p) if self.top_p is not None else None
-        self.top_k = float(self.top_k) if self.top_k is not None else None
 
     def get_params_as_dict(self, pop_null=True) -> Dict[str, Any]:
         """

--- a/source/lambda/chat/llm_models/models/bedrock_cohere_params.py
+++ b/source/lambda/chat/llm_models/models/bedrock_cohere_params.py
@@ -12,7 +12,7 @@
 #  and limitations under the License.                                                                                #
 ######################################################################################################################
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from llm_models.models.bedrock_llm_params import BedrockLLMParams
@@ -21,46 +21,33 @@ from utils.enum_types import BedrockModelProviders
 
 
 @dataclass
-class BedrockTitanLLMParams(BedrockLLMParams):
+class BedrockCohereLLMParams(BedrockLLMParams):
     """
-    Model parameters for the Amazon Titan Bedrock model.
-    The class also provides logic to parse and clean model parameters specifically for the Amazon Titan Bedrock model.
+    Model parameters for the Anthropic model available in Bedrock.
+    The class also provides logic to parse and clean model parameters specifically for the Amazon AI21 Bedrock model.
     """
 
-    maxTokenCount: Optional[int] = None
-    stopSequences: Optional[List[str]] = field(default_factory=list)
-    topP: Optional[float] = None
-    temperature: Optional[float] = DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.AMAZON.value]
+    num_generations: Optional[int] = None
+    logit_bias: Optional[Dict[str, float]] = None
+    stream: Optional[bool] = None
+    return_likelihoods: Optional[str] = None
+    temperature: Optional[float] = DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.COHERE.value]
+    p: Optional[float] = None
+    k: Optional[float] = None
+    max_tokens: Optional[int] = None
+    truncate: Optional[str] = None
+    stop_sequences: Optional[List[str]] = None
 
     def __post_init__(self):
         """
         Parses model_params to produce clean model parameters per the standards of the an underlying Bedrock model family
-        For example, for Amazon Titan,
-            if provided with:
-                {
-                    "maxTokenCount": 250,
-                    "stopSequences": '\nAI:, \nHuman:'
-                    "temperature": 0.2,
-                    "topP": None
-                }
-            the response is:
-                BedrockTitanLLMParams(model_params={'maxTokenCount': 250, 'stopSequences': ['|', '\nAI:', '\nHuman:'], 'temperature': 0.2})
-
-        Empty keys are dropped from the BedrockTitanLLMParams dataclass object. All model parameters are optional.
-        Temperature is set to model default value if not provided.
-        Stop sequences are also set to a default if a default exists for that model provider.
-
+        Empty keys are dropped from the BedrockCohereLLMParams dataclass object. All model parameters are optional.
+        Stop sequences are extended to include defaults if a default exists for that model provider.
         """
-        user_stop_sequences = self.stopSequences if self.stopSequences else []
-        self.stopSequences = list(
-            sorted(set(BEDROCK_STOP_SEQUENCES[BedrockModelProviders.AMAZON.value] + user_stop_sequences))
+        user_stop_sequences = self.stop_sequences if self.stop_sequences is not None else []
+        self.stop_sequences = list(
+            sorted(set(BEDROCK_STOP_SEQUENCES[BedrockModelProviders.COHERE.value] + user_stop_sequences))
         )
-        self.temperature = (
-            float(self.temperature)
-            if self.temperature is not None
-            else DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.AMAZON.value]
-        )
-        self.topP = float(self.topP) if self.topP is not None else None
 
     def get_params_as_dict(self, pop_null=True) -> Dict[str, Any]:
         """
@@ -72,4 +59,4 @@ class BedrockTitanLLMParams(BedrockLLMParams):
         Returns:
             (Dict): Dict of the model parameters.
         """
-        return super().get_params_as_dict(stop_sequence_key="stopSequences", pop_null=pop_null)
+        return super().get_params_as_dict(stop_sequence_key="stop_sequences", pop_null=pop_null)

--- a/source/lambda/chat/llm_models/models/bedrock_meta_params.py
+++ b/source/lambda/chat/llm_models/models/bedrock_meta_params.py
@@ -12,29 +12,33 @@
 #  and limitations under the License.                                                                                #
 ######################################################################################################################
 
-import pytest
-from llm_models.factories.bedrock_adapter_factory import BedrockAdapterFactory
-from llm_models.models.bedrock_ai21_params import BedrockAI21LLMParams
-from llm_models.models.bedrock_anthropic_params import BedrockAnthropicLLMParams
-from llm_models.models.bedrock_amazon_params import BedrockAmazonLLMParams
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from llm_models.models.bedrock_llm_params import BedrockLLMParams
+from utils.constants import DEFAULT_BEDROCK_TEMPERATURE_MAP
 from utils.enum_types import BedrockModelProviders
 
 
-@pytest.mark.parametrize(
-    "model_family, expected_adapter",
-    [
-        (BedrockModelProviders.ANTHROPIC.value, BedrockAnthropicLLMParams),
-        (BedrockModelProviders.AMAZON.value, BedrockAmazonLLMParams),
-        (BedrockModelProviders.AI21.value, BedrockAI21LLMParams),
-    ],
-)
-def test_sanitizer_passes(model_family, expected_adapter):
-    bedrock_adapter = BedrockAdapterFactory().get_bedrock_adapter(model_family)
-    assert bedrock_adapter == expected_adapter
+@dataclass
+class BedrockMetaLLMParams(BedrockLLMParams):
+    """
+    Model parameters for the Meta model available in Bedrock.
+    The class also provides logic to parse and clean model parameters specifically for the Amazon Meta Bedrock model.
+    """
 
+    max_gen_len: Optional[int] = None
+    top_p: Optional[float] = None
+    temperature: float = DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.META.value]
 
-def test_sanitizer_fails():
-    with pytest.raises(ValueError) as error:
-        BedrockAdapterFactory().get_bedrock_adapter("Ai21")
+    def get_params_as_dict(self, pop_null=True) -> Dict[str, Any]:
+        """
+        Takes the model dataclass object and returns a dict of the model parameters.
 
-    assert error.value.args[0] == "BedrockAdapterFactory: Provided model family is not supported."
+        Args:
+            pop_null (bool): If true, pops the null/empty values from the dict.
+
+        Returns:
+            (Dict): Dict of the model parameters.
+        """
+        return super().get_params_as_dict(pop_null=pop_null)

--- a/source/lambda/chat/llm_models/models/llm_params.py
+++ b/source/lambda/chat/llm_models/models/llm_params.py
@@ -40,9 +40,7 @@ class LLMParams(ABC):
         Returns:
             (Dict): Dict of the model parameters.
         """
-        lambda_func = (
-            lambda x: {k: v for (k, v) in x if v is not None and v != {}} if pop_null else {k: v for (k, v) in x}
-        )
+        lambda_func = lambda x: {k: v for (k, v) in x if v is not None} if pop_null else {k: v for (k, v) in x}
 
         response = {k: v for k, v in asdict(self, dict_factory=lambda_func).items()}
 

--- a/source/lambda/chat/llm_models/rag/bedrock_retrieval.py
+++ b/source/lambda/chat/llm_models/rag/bedrock_retrieval.py
@@ -26,6 +26,7 @@ from llm_models.bedrock import BedrockLLM
 from shared.knowledge.knowledge_base import KnowledgeBase
 from utils.constants import (
     DEFAULT_BEDROCK_ANTHROPIC_CONDENSING_PROMPT_TEMPLATE,
+    DEFAULT_BEDROCK_META_CONDENSING_PROMPT_TEMPLATE,
     DEFAULT_BEDROCK_MODEL_FAMILY,
     DEFAULT_BEDROCK_STREAMING_MODE,
     DEFAULT_BEDROCK_TEMPERATURE_MAP,
@@ -88,11 +89,12 @@ class BedrockRetrievalLLM(BedrockLLM):
         if condensing_prompt_template:
             self.condensing_prompt_template = condensing_prompt_template
         else:
-            self.condensing_prompt_template = (
-                DEFAULT_BEDROCK_ANTHROPIC_CONDENSING_PROMPT_TEMPLATE
-                if model_family == BedrockModelProviders.ANTHROPIC.value
-                else CONDENSE_QUESTION_PROMPT
-            )
+            if model_family == BedrockModelProviders.ANTHROPIC.value:
+                self.condensing_prompt_template = DEFAULT_BEDROCK_ANTHROPIC_CONDENSING_PROMPT_TEMPLATE
+            elif model_family == BedrockModelProviders.META.value:
+                self.condensing_prompt_template = DEFAULT_BEDROCK_META_CONDENSING_PROMPT_TEMPLATE
+            else:
+                self.condensing_prompt_template = CONDENSE_QUESTION_PROMPT
 
         super().__init__(
             conversation_memory=conversation_memory,

--- a/source/lambda/chat/test/clients/builders/test_bedrock_builder.py
+++ b/source/lambda/chat/test/clients/builders/test_bedrock_builder.py
@@ -120,7 +120,7 @@ def test_set_llm_model(
     assert builder.llm_model.model == config["LlmParams"]["ModelId"]
     assert builder.llm_model.prompt_template.template == prompt
     assert set(builder.llm_model.prompt_template.input_variables) == set(placeholders)
-    assert builder.llm_model.model_params["temperature"] == 0.0
+    assert builder.llm_model.model_params["temperature"] == 0.2
     assert sorted(builder.llm_model.model_params["stopSequences"]) == ["|"]
     assert builder.llm_model.streaming == config["LlmParams"]["Streaming"]
     assert builder.llm_model.verbose == config["LlmParams"]["Verbose"]

--- a/source/lambda/chat/test/llm_models/models/test_bedrock_ai21_params.py
+++ b/source/lambda/chat/test/llm_models/models/test_bedrock_ai21_params.py
@@ -24,7 +24,6 @@ from utils.enum_types import BedrockModelProviders
         (
             {
                 "maxTokens": 512,
-                "stopSequences": [],
                 "temperature": 0.9,
                 "presencePenalty": {"scale": 0},
                 "countPenalty": {"scale": 0},
@@ -33,6 +32,7 @@ from utils.enum_types import BedrockModelProviders
             {
                 "maxTokens": 512,
                 "temperature": 0.9,
+                "stopSequences": [],
                 "presencePenalty": {"scale": 0},
                 "countPenalty": {"scale": 0},
                 "frequencyPenalty": {"scale": 0},
@@ -60,18 +60,18 @@ from utils.enum_types import BedrockModelProviders
         ),
         (
             {},
-            {"temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.AI21.value]},
+            {"temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.AI21.value], "stopSequences": []},
         ),
     ],
 )
 def test_ai21_params_dataclass_success(params, expected_response):
     bedrock_params = BedrockAI21LLMParams(**params)
     assert bedrock_params.temperature == expected_response["temperature"]
-    assert bedrock_params.maxTokens == expected_response.get("maxTokens", None)
-    assert sorted(bedrock_params.stopSequences) == expected_response.get("stopSequences", [])
-    assert bedrock_params.presencePenalty == expected_response.get("presencePenalty", {})
-    assert bedrock_params.countPenalty == expected_response.get("countPenalty", {})
-    assert bedrock_params.frequencyPenalty == expected_response.get("frequencyPenalty", {})
+    assert bedrock_params.maxTokens == expected_response.get("maxTokens")
+    assert sorted(bedrock_params.stopSequences) == expected_response.get("stopSequences")
+    assert bedrock_params.presencePenalty == expected_response.get("presencePenalty")
+    assert bedrock_params.countPenalty == expected_response.get("countPenalty")
+    assert bedrock_params.frequencyPenalty == expected_response.get("frequencyPenalty")
 
 
 @pytest.mark.parametrize(
@@ -98,9 +98,9 @@ def test_ai21_params_dataclass_success(params, expected_response):
             {
                 "maxTokens": None,
                 "topP": None,
-                "countPenalty": {},
-                "presencePenalty": {},
-                "frequencyPenalty": {},
+                "countPenalty": None,
+                "presencePenalty": None,
+                "frequencyPenalty": None,
                 "stopSequences": [],
                 "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.AI21.value],
             },
@@ -111,9 +111,9 @@ def test_ai21_params_dataclass_success(params, expected_response):
             {
                 "maxTokens": None,
                 "topP": 0.2,
-                "countPenalty": {},
-                "presencePenalty": {},
-                "frequencyPenalty": {},
+                "countPenalty": None,
+                "presencePenalty": None,
+                "frequencyPenalty": None,
                 "stopSequences": [],
                 "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.AI21.value],
             },
@@ -123,3 +123,19 @@ def test_ai21_params_dataclass_success(params, expected_response):
 def test_ai21_get_params_as_dict(pop_null, params, expected_response):
     bedrock_params = BedrockAI21LLMParams(**params)
     assert bedrock_params.get_params_as_dict(pop_null=pop_null) == expected_response
+
+
+def test_ai21_incorrect_params():
+    with pytest.raises(TypeError) as error:
+        BedrockAI21LLMParams(
+            **{
+                "maxTokens": 512,
+                "temperature": 0.9,
+                "presencePenalty": {"scale": 0},
+                "countPenalty": {"scale": 0},
+                "frequencyPenalty": {"scale": 0},
+                "incorrect_param": 0.1,
+            }
+        )
+
+    assert error.value.args[0] == "BedrockAI21LLMParams.__init__() got an unexpected keyword argument 'incorrect_param'"

--- a/source/lambda/chat/test/llm_models/models/test_bedrock_amazon_params.py
+++ b/source/lambda/chat/test/llm_models/models/test_bedrock_amazon_params.py
@@ -13,7 +13,7 @@
 ######################################################################################################################
 
 import pytest
-from llm_models.models.bedrock_titan_params import BedrockTitanLLMParams
+from llm_models.models.bedrock_amazon_params import BedrockAmazonLLMParams
 from utils.constants import DEFAULT_BEDROCK_TEMPERATURE_MAP
 from utils.enum_types import BedrockModelProviders
 
@@ -22,7 +22,7 @@ from utils.enum_types import BedrockModelProviders
     "params, expected_response",
     [
         (
-            {"maxTokenCount": 512, "topP": 0.2, "stopSequences": "", "temperature": 0.2},
+            {"maxTokenCount": 512, "topP": 0.2, "temperature": 0.2},
             {"maxTokenCount": 512, "topP": 0.2, "stopSequences": ["|"], "temperature": 0.2},
         ),
         (
@@ -30,7 +30,7 @@ from utils.enum_types import BedrockModelProviders
             {"maxTokenCount": 512, "topP": 0.2, "stopSequences": ["ai:", "human:", "|"], "temperature": 0.2},
         ),
         (
-            {"maxTokenCount": 512, "topP": 0.2, "stopSequences": ""},
+            {"maxTokenCount": 512, "topP": 0.2},
             {
                 "maxTokenCount": 512,
                 "topP": 0.2,
@@ -47,11 +47,11 @@ from utils.enum_types import BedrockModelProviders
         ),
     ],
 )
-def test_ai21_params_dataclass_success(params, expected_response):
-    bedrock_params = BedrockTitanLLMParams(**params)
+def test_amazon_params_dataclass_success(params, expected_response):
+    bedrock_params = BedrockAmazonLLMParams(**params)
     assert bedrock_params.temperature == expected_response["temperature"]
-    assert bedrock_params.maxTokenCount is expected_response.get("maxTokenCount", None)
-    assert bedrock_params.topP == expected_response.get("topP", None)
+    assert bedrock_params.maxTokenCount is expected_response.get("maxTokenCount")
+    assert bedrock_params.topP == expected_response.get("topP")
     assert sorted(bedrock_params.stopSequences) == expected_response.get("stopSequences", [])
 
 
@@ -97,6 +97,22 @@ def test_ai21_params_dataclass_success(params, expected_response):
         ),
     ],
 )
-def test_ai21_get_params_as_dict(pop_null, params, expected_response):
-    bedrock_params = BedrockTitanLLMParams(**params)
+def test_amazon_get_params_as_dict(pop_null, params, expected_response):
+    bedrock_params = BedrockAmazonLLMParams(**params)
     assert bedrock_params.get_params_as_dict(pop_null=pop_null) == expected_response
+
+
+def test_amazon_incorrect_params():
+    with pytest.raises(TypeError) as error:
+        BedrockAmazonLLMParams(
+            **{
+                "maxTokenCount": 512,
+                "topP": 0.2,
+                "temperature": 0.2,
+                "incorrect_param": 0.1,
+            }
+        )
+
+    assert (
+        error.value.args[0] == "BedrockAmazonLLMParams.__init__() got an unexpected keyword argument 'incorrect_param'"
+    )

--- a/source/lambda/chat/test/llm_models/models/test_bedrock_cohere_params.py
+++ b/source/lambda/chat/test/llm_models/models/test_bedrock_cohere_params.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+######################################################################################################################
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.                                                #
+#                                                                                                                    #
+#  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance    #
+#  with the License. A copy of the License is located at                                                             #
+#                                                                                                                    #
+#      http://www.apache.org/licenses/LICENSE-2.0                                                                    #
+#                                                                                                                    #
+#  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES #
+#  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions    #
+#  and limitations under the License.                                                                                #
+######################################################################################################################
+
+import pytest
+from llm_models.models.bedrock_cohere_params import BedrockCohereLLMParams
+from utils.constants import DEFAULT_BEDROCK_TEMPERATURE_MAP
+from utils.enum_types import BedrockModelProviders
+
+
+@pytest.mark.parametrize(
+    "params, expected_response",
+    [
+        (
+            {
+                "num_generations": 10,  # all values provided
+                "logit_bias": {"token_id": 0.2},
+                "stream": True,
+                "return_likelihoods": "ALL",
+                "p": 0.2,
+                "k": 250,
+                "max_tokens": 300,
+                "truncate": "END",
+                "stop_sequences": ["sequence", "some"],
+                "temperature": 0.1,
+            },
+            {
+                "num_generations": 10,
+                "logit_bias": {"token_id": 0.2},
+                "stream": True,
+                "return_likelihoods": "ALL",
+                "p": 0.2,
+                "k": 250,
+                "max_tokens": 300,
+                "truncate": "END",
+                "stop_sequences": ["sequence", "some"],
+                "temperature": 0.1,
+            },
+        ),
+        (
+            {
+                "num_generations": 10,  # missing temperature
+                "logit_bias": {"token_id": 0.2},
+                "stream": True,
+                "return_likelihoods": "ALL",
+                "p": 0.2,
+                "k": 250,
+                "max_tokens": 300,
+                "truncate": "END",
+            },
+            {
+                "num_generations": 10,
+                "logit_bias": {"token_id": 0.2},
+                "stream": True,
+                "return_likelihoods": "ALL",
+                "p": 0.2,
+                "k": 250,
+                "max_tokens": 300,
+                "truncate": "END",
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.COHERE.value],
+            },
+        ),
+        (
+            {},  # no params
+            {
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.COHERE.value],
+            },
+        ),
+    ],
+)
+def test_cohere_params_dataclass_success(params, expected_response):
+    bedrock_params = BedrockCohereLLMParams(**params)
+    assert bedrock_params.num_generations == expected_response.get("num_generations")
+    assert bedrock_params.logit_bias == expected_response.get("logit_bias")
+    assert bedrock_params.stream == expected_response.get("stream")
+    assert bedrock_params.return_likelihoods == expected_response.get("return_likelihoods")
+    assert bedrock_params.p == expected_response.get("p")
+    assert bedrock_params.k == expected_response.get("k")
+    assert bedrock_params.max_tokens == expected_response.get("max_tokens")
+    assert bedrock_params.truncate == expected_response.get("truncate")
+    assert bedrock_params.temperature == expected_response.get("temperature")
+    assert sorted(bedrock_params.stop_sequences) == expected_response.get("stop_sequences", [])
+
+
+@pytest.mark.parametrize(
+    "pop_null, params, expected_response",
+    [
+        (
+            True,
+            {"p": 0.2, "k": 250, "max_tokens": 300},
+            {
+                "p": 0.2,
+                "k": 250,
+                "max_tokens": 300,
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.COHERE.value],
+            },
+        ),
+        (
+            True,
+            {},
+            {
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.COHERE.value],
+            },
+        ),
+        (
+            False,
+            {},
+            {
+                "k": None,
+                "logit_bias": None,
+                "max_tokens": None,
+                "num_generations": None,
+                "p": None,
+                "return_likelihoods": None,
+                "stop_sequences": [],
+                "stream": None,
+                "temperature": 0.75,
+                "truncate": None,
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.COHERE.value],
+            },
+        ),
+        (
+            False,
+            {"p": 0.2, "k": 250, "max_tokens": 300},
+            {
+                "p": 0.2,
+                "k": 250,
+                "max_tokens": 300,
+                "logit_bias": None,
+                "num_generations": None,
+                "return_likelihoods": None,
+                "stop_sequences": [],
+                "stream": None,
+                "temperature": 0.75,
+                "truncate": None,
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.COHERE.value],
+            },
+        ),
+    ],
+)
+def test_cohere_get_params_as_dict(pop_null, params, expected_response):
+    bedrock_params = BedrockCohereLLMParams(**params)
+    assert bedrock_params.get_params_as_dict(pop_null=pop_null) == expected_response
+
+
+def test_cohere_incorrect_params():
+    with pytest.raises(TypeError) as error:
+        BedrockCohereLLMParams(
+            **{
+                "num_generations": 10,
+                "logit_bias": {"token_id": 0.2},
+                "stream": True,
+                "return_likelihoods": "ALL",
+                "p": 0.2,
+                "k": 250,
+                "max_tokens": 300,
+                "truncate": "END",
+                "stop_sequences": ["sequence", "some"],
+                "incorrect_param": 0.1,
+            }
+        )
+
+    assert (
+        error.value.args[0] == "BedrockCohereLLMParams.__init__() got an unexpected keyword argument 'incorrect_param'"
+    )

--- a/source/lambda/chat/test/llm_models/models/test_bedrock_meta_params.py
+++ b/source/lambda/chat/test/llm_models/models/test_bedrock_meta_params.py
@@ -13,7 +13,7 @@
 ######################################################################################################################
 
 import pytest
-from llm_models.models.bedrock_anthropic_params import BedrockAnthropicLLMParams
+from llm_models.models.bedrock_meta_params import BedrockMetaLLMParams
 from utils.constants import DEFAULT_BEDROCK_TEMPERATURE_MAP
 from utils.enum_types import BedrockModelProviders
 
@@ -22,60 +22,34 @@ from utils.enum_types import BedrockModelProviders
     "params, expected_response",
     [
         (
-            {"max_tokens_to_sample": 512, "top_p": 0.2, "top_k": 0.2, "temperature": 0.2},
+            {"max_gen_len": 512, "top_p": 0.2, "temperature": 0.2},
             {
-                "max_tokens_to_sample": 512,
+                "max_gen_len": 512,
                 "top_p": 0.2,
-                "top_k": 0.2,
-                "stop_sequences": [],
                 "temperature": 0.2,
             },
         ),
         (
+            {"max_gen_len": 512, "top_p": 0.2},
             {
-                "max_tokens_to_sample": 512,
+                "max_gen_len": 512,
                 "top_p": 0.2,
-                "top_k": 0.2,
-                "stop_sequences": ["human:", "ai:"],
-                "temperature": 0.2,
-            },
-            {
-                "max_tokens_to_sample": 512,
-                "top_p": 0.2,
-                "top_k": 0.2,
-                "stop_sequences": ["ai:", "human:"],
-                "temperature": 0.2,
-            },
-        ),
-        (
-            {
-                "max_tokens_to_sample": 512,
-                "top_p": 0.2,
-                "top_k": 0.2,
-            },
-            {
-                "max_tokens_to_sample": 512,
-                "top_p": 0.2,
-                "top_k": 0.2,
-                "stop_sequences": [],
-                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value],
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.META.value],
             },
         ),
         (
             {},
             {
-                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value],
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.META.value],
             },
         ),
     ],
 )
-def test_anthropic_params_dataclass_success(params, expected_response):
-    bedrock_params = BedrockAnthropicLLMParams(**params)
+def test_meta_params_dataclass_success(params, expected_response):
+    bedrock_params = BedrockMetaLLMParams(**params)
     assert bedrock_params.temperature == expected_response["temperature"]
-    assert bedrock_params.max_tokens_to_sample is expected_response.get("max_tokens_to_sample")
+    assert bedrock_params.max_gen_len == expected_response.get("max_gen_len")
     assert bedrock_params.top_p == expected_response.get("top_p")
-    assert bedrock_params.top_k == expected_response.get("top_k")
-    assert bedrock_params.stop_sequences == expected_response.get("stop_sequences", [])
 
 
 @pytest.mark.parametrize(
@@ -86,58 +60,50 @@ def test_anthropic_params_dataclass_success(params, expected_response):
             {"top_p": 0.2},
             {
                 "top_p": 0.2,
-                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value],
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.META.value],
             },
         ),
         (
             True,
             {},
             {
-                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value],
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.META.value],
             },
         ),
         (
             False,
             {},
             {
-                "max_tokens_to_sample": None,
+                "max_gen_len": None,
                 "top_p": None,
-                "top_k": None,
-                "stop_sequences": [],
-                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value],
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.META.value],
             },
         ),
         (
             False,
             {"top_p": 0.2},
             {
-                "max_tokens_to_sample": None,
+                "max_gen_len": None,
                 "top_p": 0.2,
-                "top_k": None,
-                "stop_sequences": [],
-                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.ANTHROPIC.value],
+                "temperature": DEFAULT_BEDROCK_TEMPERATURE_MAP[BedrockModelProviders.META.value],
             },
         ),
     ],
 )
-def test_anthropic_get_params_as_dict(pop_null, params, expected_response):
-    bedrock_params = BedrockAnthropicLLMParams(**params)
+def test_meta_get_params_as_dict(pop_null, params, expected_response):
+    bedrock_params = BedrockMetaLLMParams(**params)
     assert bedrock_params.get_params_as_dict(pop_null=pop_null) == expected_response
 
 
-def test_anthropic_incorrect_params():
+def test_meta_incorrect_params():
     with pytest.raises(TypeError) as error:
-        BedrockAnthropicLLMParams(
+        BedrockMetaLLMParams(
             **{
-                "max_tokens_to_sample": 512,
+                "max_gen_len": 512,
                 "top_p": 0.2,
-                "top_k": 0.2,
                 "temperature": 0.2,
                 "incorrect_param": 0.1,
             }
         )
 
-    assert (
-        error.value.args[0]
-        == "BedrockAnthropicLLMParams.__init__() got an unexpected keyword argument 'incorrect_param'"
-    )
+    assert error.value.args[0] == "BedrockMetaLLMParams.__init__() got an unexpected keyword argument 'incorrect_param'"

--- a/source/lambda/chat/test/llm_models/rag/test_anthropic_retrieval.py
+++ b/source/lambda/chat/test/llm_models/rag/test_anthropic_retrieval.py
@@ -47,6 +47,7 @@ def anthropic_model(is_streaming, setup_environment):
         },
         prompt_template=DEFAULT_ANTHROPIC_RAG_PROMPT,
         streaming=is_streaming,
+        temperature=0.3,
         verbose=False,
         callbacks=None,
     )
@@ -61,7 +62,7 @@ def test_implement_error_not_raised(chat_fixture, is_streaming, request):
         assert chat_model.prompt_template.template == DEFAULT_ANTHROPIC_RAG_PROMPT
         assert set(chat_model.prompt_template.input_variables) == set(DEFAULT_ANTHROPIC_RAG_PLACEHOLDERS)
         assert chat_model.model_params == {
-            "temperature": DEFAULT_ANTHROPIC_TEMPERATURE,
+            "temperature": 0.3,
             "max_tokens_to_sample": 200,
             "top_p": 0.2,
         }
@@ -116,5 +117,5 @@ def test_exception_for_failed_model_incorrect_key(setup_environment, is_streamin
 
     assert (
         error.value.args[0]
-        == "ChatAnthropic model construction failed. API key was incorrect. Error: Error code: 401 - {'error': {'type': 'authentication_error', 'message': 'Invalid API Key'}}"
+        == "ChatAnthropic model construction failed. API key was incorrect. Error: Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'Invalid API Key'}}"
     )

--- a/source/lambda/chat/test/llm_models/rag/test_huggingface_retrieval.py
+++ b/source/lambda/chat/test/llm_models/rag/test_huggingface_retrieval.py
@@ -47,6 +47,7 @@ def huggingface_model(is_streaming, setup_environment):
         },
         prompt_template=DEFAULT_HUGGINGFACE_RAG_PROMPT,
         streaming=is_streaming,
+        temperature=0.3,
         verbose=False,
         callbacks=None,
     )
@@ -62,7 +63,7 @@ def test_implement_error_not_raised(chat_fixture, is_streaming, request):
         assert set(chat_model.prompt_template.input_variables) == set(DEFAULT_HUGGINGFACE_RAG_PLACEHOLDERS)
         assert chat_model.model_params == {
             "top_p": 0.2,
-            "temperature": DEFAULT_HUGGINGFACE_TEMPERATURE,
+            "temperature": 0.3,
             "max_length": 100,
         }
         assert chat_model.api_token == "fake-token"

--- a/source/lambda/chat/test/llm_models/test_anthropic.py
+++ b/source/lambda/chat/test/llm_models/test_anthropic.py
@@ -132,7 +132,7 @@ def test_exception_for_failed_model_incorrect_key(setup_environment, is_streamin
 
     assert (
         error.value.args[0]
-        == "ChatAnthropic model construction failed. API key was incorrect. Error: Error code: 401 - {'error': {'type': 'authentication_error', 'message': 'Invalid API Key'}}"
+        == "ChatAnthropic model construction failed. API key was incorrect. Error: Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error', 'message': 'Invalid API Key'}}"
     )
 
 

--- a/source/lambda/chat/test/utils/test_helpers.py
+++ b/source/lambda/chat/test/utils/test_helpers.py
@@ -76,7 +76,7 @@ def test_validate_prompt_template_valid(prompt_template, required_placeholders):
         ("false", "boolean", False, bool),
         ('["\nHuman:", "\nAI:"]', "list", ["\nHuman:", "\nAI:"], list),
         ('["|"]', "list", ["|"], list),
-        ('{"scale": 0}', "dict", {"scale": 0}, dict),
+        ('{"scale": 0}', "dictionary", {"scale": 0}, dict),
     ],
 )
 def test_valid_type_casting(value, data_type, response, response_type, setup_environment):

--- a/source/lambda/chat/utils/constants.py
+++ b/source/lambda/chat/utils/constants.py
@@ -14,6 +14,7 @@
 import os
 
 from langchain.prompts import PromptTemplate
+from langchain.chains.conversational_retrieval.prompts import CONDENSE_QUESTION_PROMPT
 from utils.enum_types import BedrockModelProviders, LLMProviderTypes
 
 # Chat environment variables
@@ -99,11 +100,15 @@ MEMORY_CONFIG = {
             BedrockModelProviders.ANTHROPIC.value: "A",
             BedrockModelProviders.AMAZON.value: "Bot",
             BedrockModelProviders.AI21.value: "AI",
+            BedrockModelProviders.META.value: "AI",
+            BedrockModelProviders.COHERE.value: "AI",
         },
         "human_prefix": {
             BedrockModelProviders.ANTHROPIC.value: "H",
             BedrockModelProviders.AMAZON.value: "User",
             BedrockModelProviders.AI21.value: "Human",
+            BedrockModelProviders.META.value: "Human",
+            BedrockModelProviders.COHERE.value: "Human",
         },
         "output": None,
     },
@@ -115,11 +120,15 @@ MEMORY_CONFIG = {
             BedrockModelProviders.ANTHROPIC.value: "A",
             BedrockModelProviders.AMAZON.value: "Bot",
             BedrockModelProviders.AI21.value: "AI",
+            BedrockModelProviders.META.value: "AI",
+            BedrockModelProviders.COHERE.value: "AI",
         },
         "human_prefix": {
             BedrockModelProviders.ANTHROPIC.value: "H",
             BedrockModelProviders.AMAZON.value: "User",
             BedrockModelProviders.AI21.value: "Human",
+            BedrockModelProviders.META.value: "Human",
+            BedrockModelProviders.COHERE.value: "Human",
         },
         "output": "answer",
     },
@@ -161,6 +170,9 @@ DEFAULT_HUGGINGFACE_RAG_PLACEHOLDERS = [
     MEMORY_CONFIG[HUGGINGFACE_RAG]["input"],
     MEMORY_CONFIG[HUGGINGFACE_RAG]["context"],
 ]
+
+DEFAULT_META_PROMPT = f"[INST] {DEFAULT_CHAT_PROMPT} [/INST]"
+DEFAULT_META_RAG_PROMPT = f"[INST] {DEFAULT_HUGGINGFACE_RAG_PROMPT} [/INST]"
 
 # Anthropic non-RAG constants
 DEFAULT_ANTHROPIC_MODEL = "claude-instant-v1"
@@ -217,6 +229,7 @@ DEFAULT_BEDROCK_MODEL_FAMILY = BedrockModelProviders.AMAZON.value
 BEDROCK_MODEL_MAP = {
     BedrockModelProviders.AMAZON.value: {
         "TITAN_TEXT_EXPRESS": "amazon.titan-text-express-v1",
+        "TITAN_TEXT_LITE": "titan-text-lite-v1",
         "DEFAULT": "amazon.titan-text-express-v1",
     },
     BedrockModelProviders.AI21.value: {
@@ -228,7 +241,18 @@ BEDROCK_MODEL_MAP = {
         "ANTHROPIC_CLAUDE_INSTANT_V1": "anthropic.claude-instant-v1",
         "ANTHROPIC_CLAUDE_V1": "anthropic.claude-v1",
         "ANTHROPIC_CLAUDE_V2": "anthropic.claude-v2",
+        "ANTHROPIC_CLAUDE_V2.1": "anthropic.claude-v2:1",
         "DEFAULT": "anthropic.claude-instant-v1",
+    },
+    BedrockModelProviders.META.value: {
+        "LLAMA_2_CHAT_13_B": "meta.llama2-13b-chat-v1",
+        "LLAMA_2_CHAT_70_B": "meta.llama2-70b-chat-v1",
+        "DEFAULT": "meta.llama2-13b-chat-v1",
+    },
+    BedrockModelProviders.COHERE.value: {
+        "COMMAND": "cohere.command-text-v14",
+        "COMMAND_LIGHT": "cohere.command-light-text-v14",
+        "DEFAULT": "cohere.command-light-text-v14",
     },
 }
 
@@ -236,11 +260,15 @@ DEFAULT_BEDROCK_TEMPERATURE_MAP = {
     BedrockModelProviders.AMAZON.value: 0.0,
     BedrockModelProviders.AI21.value: 0.7,
     BedrockModelProviders.ANTHROPIC.value: 1,
+    BedrockModelProviders.META.value: 0.5,
+    BedrockModelProviders.COHERE.value: 0.75,
 }
 BEDROCK_STOP_SEQUENCES = {
     BedrockModelProviders.ANTHROPIC.value: [],
     BedrockModelProviders.AMAZON.value: ["|"],
     BedrockModelProviders.AI21.value: [],
+    BedrockModelProviders.META.value: [],
+    BedrockModelProviders.COHERE.value: [],
 }
 DEFAULT_BEDROCK_RAG_ENABLED_MODE = False
 DEFAULT_BEDROCK_STREAMING_MODE = False
@@ -250,6 +278,8 @@ DEFAULT_BEDROCK_PROMPT = {
     BedrockModelProviders.AMAZON.value: DEFAULT_CHAT_PROMPT,
     BedrockModelProviders.AI21.value: DEFAULT_CHAT_PROMPT,
     BedrockModelProviders.ANTHROPIC.value: DEFAULT_ANTHROPIC_PROMPT,
+    BedrockModelProviders.META.value: DEFAULT_META_PROMPT,
+    BedrockModelProviders.COHERE.value: DEFAULT_CHAT_PROMPT,
 }
 
 DEFAULT_BEDROCK_PLACEHOLDERS = [
@@ -273,6 +303,8 @@ User: {question}
 Bot:""",
     BedrockModelProviders.AI21.value: DEFAULT_HUGGINGFACE_RAG_PROMPT,
     BedrockModelProviders.ANTHROPIC.value: DEFAULT_ANTHROPIC_RAG_PROMPT,
+    BedrockModelProviders.META.value: DEFAULT_META_RAG_PROMPT,
+    BedrockModelProviders.COHERE.value: DEFAULT_HUGGINGFACE_RAG_PROMPT,
 }
 
 DEFAULT_BEDROCK_RAG_PLACEHOLDERS = [
@@ -296,6 +328,10 @@ Assistant: Standalone question:"""
 
 DEFAULT_BEDROCK_ANTHROPIC_CONDENSING_PROMPT_TEMPLATE = PromptTemplate.from_template(
     DEFAULT_BEDROCK_ANTHROPIC_CONDENSING_PROMPT
+)
+
+DEFAULT_BEDROCK_META_CONDENSING_PROMPT_TEMPLATE = PromptTemplate.from_template(
+    f"[INST] {CONDENSE_QUESTION_PROMPT.template} [/INST]"
 )
 
 # Chat environment variables

--- a/source/lambda/chat/utils/enum_types.py
+++ b/source/lambda/chat/utils/enum_types.py
@@ -41,6 +41,8 @@ class BedrockModelProviders(str, Enum):
     AI21 = "AI21"
     ANTHROPIC = "ANTHROPIC"
     AMAZON = "AMAZON_TITAN"
+    META = "META"
+    COHERE = "COHERE"
 
 
 class CloudWatchNamespaces(str, Enum):

--- a/source/lambda/chat/utils/helpers.py
+++ b/source/lambda/chat/utils/helpers.py
@@ -30,7 +30,7 @@ TYPE_CASTING_MAP = {
     "string": str,
     "boolean": lambda value: value.lower() in ["true", "yes"],
     "list": lambda value: json.loads(value, strict=False),
-    "dict": lambda value: json.loads(value),
+    "dictionary": lambda value: json.loads(value),
 }
 
 

--- a/source/lambda/custom-authorizer/package-lock.json
+++ b/source/lambda/custom-authorizer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "custom-authorizer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "custom-authorizer",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-jwt-verify": "4.0.0"

--- a/source/lambda/custom-authorizer/package.json
+++ b/source/lambda/custom-authorizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-authorizer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This lambda function is used as a custom REQUEST authorizer for APIs",
   "main": "rest-handler.ts",
   "scripts": {

--- a/source/lambda/layers/aws-node-user-agent-config/package-lock.json
+++ b/source/lambda/layers/aws-node-user-agent-config/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-node-user-agent-config",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-node-user-agent-config",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^1.14.0",

--- a/source/lambda/layers/aws-node-user-agent-config/package.json
+++ b/source/lambda/layers/aws-node-user-agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-node-user-agent-config",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "AWS Nodejs SDK Config intialization layer",
   "main": "index.js",
   "scripts": {

--- a/source/lambda/layers/aws-sdk-lib/package-lock.json
+++ b/source/lambda/layers/aws-sdk-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sdk-layer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-sdk-layer",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.423.0",

--- a/source/lambda/layers/aws-sdk-lib/package.json
+++ b/source/lambda/layers/aws-sdk-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-layer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "AWS Javascript SDK v3 layer",
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.423.0",

--- a/source/lambda/layers/langchain/requirements.txt
+++ b/source/lambda/layers/langchain/requirements.txt
@@ -1,2 +1,2 @@
-langchain==0.0.335
+langchain==0.0.350
 numpy==1.26.0

--- a/source/lambda/use-case-management/cfn/stack-management.ts
+++ b/source/lambda/use-case-management/cfn/stack-management.ts
@@ -160,9 +160,8 @@ export class StackManagement {
             metrics.addMetric(CloudWatchMetrics.UC_DESCRIBE_FAILURE, MetricUnits.Count, 1);
             logger.error(`Error occurred when describing stack, error is ${error}`);
             throw error;
-        }
-        finally {
-            metrics.publishStoredMetrics()
+        } finally {
+            metrics.publishStoredMetrics();
         }
     }
 

--- a/source/lambda/use-case-management/ddb/storage-operation-builder.ts
+++ b/source/lambda/use-case-management/ddb/storage-operation-builder.ts
@@ -81,7 +81,8 @@ export class UpdateItemCommandBuilder extends CommandInputBuilder {
             Key: {
                 UseCaseId: { S: this.useCase.useCaseId }
             },
-            UpdateExpression: 'SET #Description = :description, #UpdatedDate = :date, #UpdatedBy = :user, #SSMParameterKey = :ssm_parameter_key',
+            UpdateExpression:
+                'SET #Description = :description, #UpdatedDate = :date, #UpdatedBy = :user, #SSMParameterKey = :ssm_parameter_key',
             ExpressionAttributeNames: {
                 ['#Description']: 'Description',
                 ['#UpdatedDate']: 'UpdatedDate',

--- a/source/lambda/use-case-management/package-lock.json
+++ b/source/lambda/use-case-management/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "use-case-management",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "use-case-management",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.1",

--- a/source/lambda/use-case-management/package.json
+++ b/source/lambda/use-case-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-case-management",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This lambda supports APIs that provide the capability to deploy GenAI use cases",
   "main": "index.ts",
   "scripts": {

--- a/source/lambda/websocket-connectors/package-lock.json
+++ b/source/lambda/websocket-connectors/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "websocket-connectors",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "websocket-connectors",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.4",

--- a/source/lambda/websocket-connectors/package.json
+++ b/source/lambda/websocket-connectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-connectors",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This lambda function is used to handle connect and disconnect requests",
   "main": "connect-handler.js",
   "scripts": {

--- a/source/ui-chat/README.md
+++ b/source/ui-chat/README.md
@@ -16,7 +16,7 @@ Follow the below steps before building the web app for local execution
 
 ```
 mkdir -p source/ui-chat/public
-touch source/ui-chat/public/runtimeConfig.js
+touch source/ui-chat/public/runtimeConfig.json
 ```
 
 -   From the AWS CloudFormation console, navigate to the `Outputs` tab of the main/ parent stack deployed and copy the `Value` of the `Key` named `WebConfigKey`.
@@ -38,7 +38,11 @@ For reference, the string in the Parameter Store should look something like the 
         "amazon.titan-text-express-v1",
         "anthropic.claude-v1",
         "anthropic.claude-v2",
-        "anthropic.claude-instant-v1"
+        "anthropic.claude-instant-v1",
+        "meta.llama2-13b-chat-v1",
+        "meta.llama2-70b-chat-v1",
+        "cohere.command-text-v14",
+        "cohere.command-light-text-v14"
     ],
     "AllowsStreaming": "true",
     "IsInternalUser": "true",

--- a/source/ui-chat/package-lock.json
+++ b/source/ui-chat/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gen-ai-app-builder-on-aws-ui-chat",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gen-ai-app-builder-on-aws-ui-chat",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.2",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
     "node_modules/@alloc/quick-lru": {
@@ -32839,9 +32839,9 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
     },
     "@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
     "@alloc/quick-lru": {

--- a/source/ui-chat/package.json
+++ b/source/ui-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gen-ai-app-builder-on-aws-ui-chat",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.2",
     "@cloudscape-design/components": "^3.0.302",

--- a/source/ui-chat/src/components/Chat.tsx
+++ b/source/ui-chat/src/components/Chat.tsx
@@ -233,11 +233,7 @@ export const Chat = memo(({ stopConversationRef, socketUrl }: Props) => { // NOS
         }
         let text = '';
         
-        if (response.message) {
-            text += "Chat service failed to respond. Please contact your administrator for support.";
-            homeDispatch({ field: 'messageIsStreaming', value: false });
-            homeDispatch({ field: 'loading', value: false });
-        } else if (response.errorMessage) {
+        if (response.errorMessage) {
             text += response.errorMessage;
             homeDispatch({ field: 'messageIsStreaming', value: false });
             homeDispatch({ field: 'loading', value: false });

--- a/source/ui-deployment/README.md
+++ b/source/ui-deployment/README.md
@@ -16,7 +16,7 @@ Follow the below steps before building the web app for local execution
 
 ```
 mkdir -p source/ui-deployment/public
-touch source/ui-deployment/public/runtimeConfig.js
+touch source/ui-deployment/public/runtimeConfig.json
 ```
 
 -   From the AWS CloudFormation console, navigate to the `Outputs` tab of the main/ parent stack deployed and copy the `Value` of the `Key` named `WebConfigKey`.
@@ -78,7 +78,11 @@ For reference, the string in the Parameter Store should look something like the 
         "amazon.titan-text-express-v1",
         "anthropic.claude-v1",
         "anthropic.claude-v2",
-        "anthropic.claude-instant-v1"
+        "anthropic.claude-instant-v1",
+        "meta.llama2-13b-chat-v1",
+        "meta.llama2-70b-chat-v1",
+        "cohere.command-text-v14",
+        "cohere.command-light-text-v14"
       ],
       "AllowsStreaming": "true"
     }

--- a/source/ui-deployment/package-lock.json
+++ b/source/ui-deployment/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gen-ai-app-builder-on-aws-ui-deployment",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gen-ai-app-builder-on-aws-ui-deployment",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.2",
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
     "node_modules/@alloc/quick-lru": {
@@ -31552,9 +31552,9 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
     },
     "@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
       "dev": true
     },
     "@alloc/quick-lru": {

--- a/source/ui-deployment/package.json
+++ b/source/ui-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gen-ai-app-builder-on-aws-ui-deployment",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.2",
     "@cloudscape-design/components": "^3.0.283",

--- a/source/ui-deployment/src/components/__tests__/__mocks__/mock-context.json
+++ b/source/ui-deployment/src/components/__tests__/__mocks__/mock-context.json
@@ -268,7 +268,11 @@
                     "amazon.titan-text-express-v1",
                     "anthropic.claude-v1",
                     "anthropic.claude-v2",
-                    "anthropic.claude-instant-v1"
+                    "anthropic.claude-instant-v1",
+                    "meta.llama2-13b-chat-v1",
+                    "meta.llama2-70b-chat-v1",
+                    "cohere.command-text-v14",
+                    "cohere.command-light-text-v14"
                 ],
                 "AllowsStreaming": "false"
             }

--- a/source/ui-deployment/src/components/__tests__/snapshot_tests/wizard/__snapshots__/WizardView.tsx.snap
+++ b/source/ui-deployment/src/components/__tests__/snapshot_tests/wizard/__snapshots__/WizardView.tsx.snap
@@ -81,7 +81,7 @@ exports[`Snapshot test 1`] = `
                         "defaultUserEmail": "",
                         "inError": false,
                         "useCase": Object {
-                          "label": "Chat",
+                          "label": "Text",
                           "value": "Chat",
                         },
                         "useCaseDescription": "",
@@ -141,7 +141,7 @@ exports[`Snapshot test 1`] = `
                         "defaultUserEmail": "",
                         "inError": false,
                         "useCase": Object {
-                          "label": "Chat",
+                          "label": "Text",
                           "value": "Chat",
                         },
                         "useCaseDescription": "",
@@ -201,7 +201,7 @@ exports[`Snapshot test 1`] = `
                         "defaultUserEmail": "",
                         "inError": false,
                         "useCase": Object {
-                          "label": "Chat",
+                          "label": "Text",
                           "value": "Chat",
                         },
                         "useCaseDescription": "",
@@ -261,7 +261,7 @@ exports[`Snapshot test 1`] = `
                         "defaultUserEmail": "",
                         "inError": false,
                         "useCase": Object {
-                          "label": "Chat",
+                          "label": "Text",
                           "value": "Chat",
                         },
                         "useCaseDescription": "",

--- a/source/ui-deployment/src/components/__tests__/snapshot_tests/wizard/stepComponents/__snapshots__/step4.jsx.snap
+++ b/source/ui-deployment/src/components/__tests__/snapshot_tests/wizard/stepComponents/__snapshots__/step4.jsx.snap
@@ -52,7 +52,7 @@ exports[`Chat Snapshot test for wizard step 4 1`] = `
               Use case
             </Box>
             <div>
-              Chat
+              Text
             </div>
           </div>
           <div>

--- a/source/ui-deployment/src/components/__tests__/snapshot_tests/wizard/stepComponents/step4.jsx
+++ b/source/ui-deployment/src/components/__tests__/snapshot_tests/wizard/stepComponents/step4.jsx
@@ -16,7 +16,6 @@ import renderer from 'react-test-renderer';
 import HomeContext from '../../../../../home/home.context';
 import Review from '../../../../wizard/stepComponents/step4';
 import {
-    DEFAULT_STEP_INFO,
     USE_CASE_OPTIONS,
     KNOWLEDGE_BASE_TYPES,
     DEFAULT_ADDITIONAL_KENDRA_QUERY_CAPACITY,

--- a/source/ui-deployment/src/components/__tests__/wizard/WizardView.tsx
+++ b/source/ui-deployment/src/components/__tests__/wizard/WizardView.tsx
@@ -101,7 +101,11 @@ describe('Wizard', () => {
                             'amazon.titan-text-express-v1',
                             'anthropic.claude-v1',
                             'anthropic.claude-v2',
-                            'anthropic.claude-instant-v1'
+                            'anthropic.claude-instant-v1',
+                            'meta.llama2-13b-chat-v1',
+                            'meta.llama2-70b-chat-v1',
+                            'cohere.command-text-v14',
+                            'cohere.command-light-text-v1'
                         ],
                         AllowsStreaming: 'false'
                     }
@@ -362,7 +366,7 @@ describe('Wizard', () => {
         const useCaseDetailsReviewComponentHtml = createWrapper(useCaseDetailsReviewComponent)?.getElement().innerHTML;
         expect(useCaseDetailsReviewComponentHtml).toContain('fake-use-case-name');
         expect(useCaseDetailsReviewComponentHtml).toContain('fake-use-case-description-name');
-        expect(useCaseDetailsReviewComponentHtml).toContain('Chat');
+        expect(useCaseDetailsReviewComponentHtml).toContain('Text');
 
         const reviewModelDetailsReviewComponent = screen.getByTestId('review-system-prompt');
         expect(reviewModelDetailsReviewComponent).toBeDefined();

--- a/source/ui-deployment/src/components/__tests__/wizard/stepComponents/step3.jsx
+++ b/source/ui-deployment/src/components/__tests__/wizard/stepComponents/step3.jsx
@@ -13,11 +13,10 @@
 
 import createWrapper from '@cloudscape-design/components/test-utils/dom';
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import HomeContext from '../../../../home/home.context';
 import WizardView from '../../../wizard/WizardView';
-import { API_NAME, INTERNAL_USER_GENAI_POLICY_URL, LEGAL_DISCLAIMER } from '../../../../utils/constants';
 import { API, Auth } from 'aws-amplify';
 
 const mockAPI = {
@@ -96,7 +95,11 @@ describe('Wizard', () => {
                             'amazon.titan-text-express-v1',
                             'anthropic.claude-v1',
                             'anthropic.claude-v2',
-                            'anthropic.claude-instant-v1'
+                            'anthropic.claude-instant-v1',
+                            'meta.llama2-13b-chat-v1',
+                            'meta.llama2-70b-chat-v1',
+                            'cohere.command-text-v14',
+                            'cohere.command-light-text-v1'
                         ],
                         AllowsStreaming: 'false'
                     }
@@ -104,17 +107,6 @@ describe('Wizard', () => {
             }
         }
     };
-
-    const mockUseWizard = jest.fn(() => ({
-        activeStepIndex: 2,
-        stepsInfo: {},
-        showErrorAlert: false,
-        useCaseDeployStatus: '',
-        setActiveStepIndexAndCloseTools: jest.fn(),
-        onStepInfoChange: jest.fn(),
-        onNavigate: jest.fn(),
-        onSubmit: jest.fn()
-    }));
 
     beforeEach(() => {
         mockAPI.post.mockReset();
@@ -134,10 +126,6 @@ describe('Wizard', () => {
             };
         });
 
-        // jest.mock('../../../wizard/WizardView', () => ({
-        //     __esModule: true,
-        //     default: mockUseWizard
-        // }));
 
         jest.mock('../../../wizard/WizardView', () => ({
             ...jest.requireActual('../../../wizard/WizardView'), // Use the actual implementation for other exports

--- a/source/ui-deployment/src/components/wizard/stepComponents/step2.jsx
+++ b/source/ui-deployment/src/components/wizard/stepComponents/step2.jsx
@@ -560,7 +560,7 @@ const generateModelParameterTypeInstructions = (type) => {
         case 'list':
             instructions = 'Please ensure it is a comma-separated list and a valid JSON string.';
             break;
-        case 'dict':
+        case 'dictionary':
             instructions = 'Please ensure it is a valid JSON string.';
             break;
     }
@@ -762,7 +762,7 @@ const Model = ({ info: { model }, setHelpPanelContent, onChange }) => {
                 case 'list':
                     isValidType = validateList(parameter);
                     break;
-                case 'dict':
+                case 'dictionary':
                     try {
                         JSON.parse(parameter.value);
                         isValidType = true;

--- a/source/ui-deployment/src/components/wizard/steps-config.jsx
+++ b/source/ui-deployment/src/components/wizard/steps-config.jsx
@@ -19,7 +19,7 @@ import {
 export const USE_CASE_OPTIONS = [
     {
         value: 'Chat',
-        label: 'Chat'
+        label: 'Text'
     }
 ];
 
@@ -102,4 +102,4 @@ export const DEFAULT_STEP_INFO = {
     }
 };
 
-export const BEDROCK_MODEL_PROVIDERS_WITH_STREAMING = ['amazon', 'anthropic'];
+export const BEDROCK_MODEL_PROVIDERS_WITH_STREAMING = ['amazon', 'anthropic', 'cohere', 'meta'];

--- a/source/ui-deployment/src/utils/constants.ts
+++ b/source/ui-deployment/src/utils/constants.ts
@@ -37,7 +37,7 @@ export const MAX_ADDITIONAL_KENDRA_QUERY_CAPACITY = 5;
 export const MIN_ADDITIONAL_KENDRA_STORAGE_CAPACITY = 0;
 export const MAX_ADDITIONAL_KENDRA_STORAGE_CAPACITY = 5;
 export const MIN_KNOWLEDGE_BASE_NUM_DOCS = 1;
-export const MAX_KNOWLEDGE_BASE_NUM_DOCS = 5;
+export const MAX_KNOWLEDGE_BASE_NUM_DOCS = 100;
 export const DELAY_AFTER_DELETE_MS = 2000; // 2 seconds
 
 export const DEFAULT_KENDRA_NUMBER_OF_DOCS = 2;
@@ -87,27 +87,15 @@ export const CFN_STACK_STATUS_INDICATOR = {
     STOPPED: 'stopped'
 };
 
-export const MODEL_PARAM_TYPES = ['string', 'integer', 'float', 'boolean', 'list', 'dict'];
+export const MODEL_PARAM_TYPES = ['string', 'integer', 'float', 'boolean', 'list', 'dictionary'];
 
 export const DEFAULT_KNOWLEDGE_BASE_TYPE = 'Kendra';
 
 export const LEGAL_DISCLAIMER = `
-Generative AI Application Builder on AWS allows you to build and deploy
-generative artificial intelligence (GAI) applications on AWS by engaging the GAI model
-of your choice, including third-party GAI models that you may choose to use that AWS
-does not own or otherwise have any control over (“Third-Party GAI Models”).
-Your use of the Third-Party GAI Models is governed by the terms provided to you
-by the Third-Party GAI Model providers when you acquired your license to use them
-(for example, their terms of service, license agreement, acceptable use policy, and privacy policy).
-You are responsible for ensuring that your use of the Third-Party GAI Models comply
-with the terms governing them, and any laws, rules, regulations, policies, or standards
-that apply to you. You are also responsible for making your own independent assessment
-of the Third-Party GAI Models that you use, including their outputs and how Third-Party
-GAI Model providers use any data that may be transmitted to them based on your deployment
-configuration. AWS does not make any representations, warranties, or guarantees regarding
-the Third-Party GAI Models, which are “Third-Party Content” under your agreement with AWS.
-Generative AI Application Builder on AWS is offered to you as
-“AWS Content” under your agreement with AWS.
+Generative AI Application Builder on AWS allows you to build and deploy generative artificial intelligence applications on AWS by engaging the generative AI model of your choice, including third-party generative AI models that you can choose to use that AWS does not own or otherwise have any control over ("Third-Party Generative AI Models").
+Your use of the Third-Party Generative AI Models is governed by the terms provided to you by the Third-Party Generative AI Model providers when you acquired your license to use them (for example, their terms of service, license agreement, acceptable use policy, and privacy policy).
+You are responsible for ensuring that your use of the Third-Party Generative AI Models comply with the terms governing them, and any laws, rules, regulations, policies, or standards that apply to you.
+You are also responsible for making your own independent assessment of the Third-Party Generative AI Models that you use, including their outputs and how Third-Party Generative AI Model providers use any data that might be transmitted to them based on your deployment configuration. AWS does not make any representations, warranties, or guarantees regarding the Third-Party Generative AI Models, which are "Third-Party Content" under your agreement with AWS. Generative AI Application Builder on AWS is offered to you as "AWS Content" under your agreement with AWS.
 `;
 
 export const KENDRA_WARNING = `


### PR DESCRIPTION
## [1.2.0] - 2023-12-18

### Added

-   Support for Amazon Titan Text Lite, Anthropic Claude v2.1, Cohere Command models, and Meta Llama 2 Chat models

### Changed

-   Increase the cap on the max number of docs retrieved in the Amazon Kendra retriever (for RAG use cases) from 5 to 100, to match the API limit

### Fixed

-   Fix typo in UI deployment instructions (#26)
-   Fix bug causing failures with dictionary type advanced model parameters
-   Fixed bug causing erroneous error messages to appear to user in long running conversations

### Security

-   Updated Python and Node package versions to resolve security vulnerabilities