### PR TITLE
Mark admin user's email as verified, by default

### DIFF
--- a/source/infrastructure/lib/auth/cognito-setup.ts
+++ b/source/infrastructure/lib/auth/cognito-setup.ts
@@ -386,6 +386,10 @@ export class CognitoSetup extends Construct {
                 {
                     name: 'email',
                     value: props.defaultUserEmail
+                },
+                {
+                    name: 'email_verified',
+                    value: 'true'
                 }
             ],
             username: this.buildUserName(props)

--- a/source/infrastructure/test/auth/deployment-platform-cognito-setup.test.ts
+++ b/source/infrastructure/test/auth/deployment-platform-cognito-setup.test.ts
@@ -231,6 +231,10 @@ describe('When cognito resources are created', () => {
                 {
                     Name: 'email',
                     Value: notificationSubscriptionEmailCapture
+                },
+                {
+                    name: 'email_verified',
+                    value: 'true'
                 }
             ],
             Username: 'fake-user'

--- a/source/infrastructure/test/auth/use-case-cognito-setup.test.ts
+++ b/source/infrastructure/test/auth/use-case-cognito-setup.test.ts
@@ -269,6 +269,10 @@ describe('When creating as a standalone stack', () => {
                 {
                     Name: 'email',
                     Value: notificationSubscriptionEmailCapture
+                },
+                {
+                    name: 'email_verified',
+                    value: 'true'
                 }
             ],
             Username: 'fake-user'


### PR DESCRIPTION
*Issue #, if available:* !180

*Description of changes:* Such that the admin user is allowed to forget their password, and reset it via the Cloudfront UI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
