### PR TITLE
Feature: Make external links in markdown open in new tabs

### DIFF
--- a/source/ui-chat/src/components/markdown/MarkdownContent.tsx
+++ b/source/ui-chat/src/components/markdown/MarkdownContent.tsx
@@ -96,6 +96,23 @@ const MARKDOWN_COMPONENTS: Components = {
      */
     td({ children }) {
         return <td className="markdown-td">{children}</td>;
+    },
+    /**
+     * Renders links with external links opening in new tabs
+     */
+    a({ href, children, ...props }) {
+        const isExternal = href && (href.startsWith('http://') || href.startsWith('https://'));
+        
+        return (
+            <a
+                href={href}
+                target={isExternal ? '_blank' : undefined}
+                rel={isExternal ? 'noopener noreferrer' : undefined}
+                {...props}
+            >
+                {children}
+            </a>
+        );
     }
 };
 


### PR DESCRIPTION
*Description of changes:*

- Adds custom anchor component to MARKDOWN_COMPONENTS
- External links (http/https) now open in new tabs with target='_blank'
- Includes rel='noopener noreferrer' for security
- Internal links remain unchanged
- Improves user experience by preventing navigation away from chat

Fixes: Users losing chat context when clicking external links

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
