### PR TITLE
Update to version v4.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.7] - 2026-03-19
+
+### Security
+
+- Upgraded `uv` to `0.10.11` to mitigate [GHSA-6gx3-4362-rf54](https://test.osv.dev/vulnerability/GHSA-6gx3-4362-rf54)
+- Upgraded `black` to `26.3.1` to mitigate [CVE-2026-32274](https://nvd.nist.gov/vuln/detail/CVE-2026-32274)
+- Upgraded `fast-xml-parser` to `5.5.6` to mitigate [CVE-2026-26278](https://nvd.nist.gov/vuln/detail/CVE-2026-26278)
+
 ## [4.1.6] - 2026-03-17
 
 ### Changed

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1522,6 +1522,7 @@ patch-package under the MIT license.
 path-case under the MIT license.
 path-exists under the MIT license.
 path-is-absolute under the MIT license.
+path-expression-matcher under the MIT license.
 path-key under the MIT license.
 path-parse under the MIT license.
 path-scurry under the BlueOak-1.0.0 license.

--- a/deployment/cdk-solution-helper/package-lock.json
+++ b/deployment/cdk-solution-helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/cdk-solution-helper",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/cdk-solution-helper",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0"
     }
   }

--- a/deployment/cdk-solution-helper/package.json
+++ b/deployment/cdk-solution-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/cdk-solution-helper",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This script performs token replacement as part of the build pipeline",
   "license": "Apache-2.0",
   "author": {

--- a/deployment/ecr/gaab-strands-agent/Dockerfile
+++ b/deployment/ecr/gaab-strands-agent/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 
 # Install pip and UV for dependency management
 RUN pip install --no-cache-dir --upgrade "pip>=25.3" \
-    && pip install --no-cache-dir "uv>=0.10.10"
+    && pip install --no-cache-dir "uv>=0.10.11"
 
 # Debug: Show build context structure
 RUN echo "=== Build context contents ===" && ls -la . 2>/dev/null || true

--- a/deployment/ecr/gaab-strands-agent/pyproject.toml
+++ b/deployment/ecr/gaab-strands-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gaab-strands-agent"
-version = "4.1.6"
+version = "4.1.7"
 description = "GAAB Strands Agent Runtime for Amazon Bedrock AgentCore"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/deployment/ecr/gaab-strands-agent/uv.lock
+++ b/deployment/ecr/gaab-strands-agent/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "gaab-strands-agent"
-version = "4.1.6"
+version = "4.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aws-opentelemetry-distro" },
@@ -715,7 +715,7 @@ dev = [
 
 [[package]]
 name = "gaab-strands-common"
-version = "4.1.6"
+version = "4.1.7"
 source = { editable = "../gaab-strands-common" }
 dependencies = [
     { name = "bedrock-agentcore" },

--- a/deployment/ecr/gaab-strands-common/pyproject.toml
+++ b/deployment/ecr/gaab-strands-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gaab-strands-common"
-version = "4.1.6"
+version = "4.1.7"
 description = "Shared library for GAAB Strands agents"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/deployment/ecr/gaab-strands-common/uv.lock
+++ b/deployment/ecr/gaab-strands-common/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "gaab-strands-common"
-version = "4.1.6"
+version = "4.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "bedrock-agentcore" },

--- a/deployment/ecr/gaab-strands-workflow-agent/Dockerfile
+++ b/deployment/ecr/gaab-strands-workflow-agent/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 
 # Install UV for dependency management
 RUN pip install --no-cache-dir --upgrade "pip>=25.3" \
-    && pip install --no-cache-dir "uv>=0.10.10"
+    && pip install --no-cache-dir "uv>=0.10.11"
 
 # Debug: Show build context structure
 RUN echo "=== Build context contents ===" && ls -la . 2>/dev/null || true

--- a/deployment/ecr/gaab-strands-workflow-agent/pyproject.toml
+++ b/deployment/ecr/gaab-strands-workflow-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gaab-strands-workflow-agent"
-version = "4.1.6"
+version = "4.1.7"
 description = "GAAB Strands Workflow Agent Runtime for Amazon Bedrock AgentCore"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -47,7 +47,7 @@ packages = ["src"]
 dev-dependencies = [
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",
-    "black>=24.0.0",
+    "black>=26.3.1",
     "isort>=5.12.0",
     "mypy>=1.8.0",
     "moto>=5.0.0",

--- a/deployment/ecr/gaab-strands-workflow-agent/uv.lock
+++ b/deployment/ecr/gaab-strands-workflow-agent/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "black"
-version = "25.9.0"
+version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -259,13 +259,19 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/43/20b5c90612d7bdb2bdbcceeb53d588acca3bb8f0e4c5d5c751a2c8fdd55a/black-25.9.0.tar.gz", hash = "sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619", size = 648393, upload-time = "2025-09-19T00:27:37.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/99/3acfea65f5e79f45472c45f87ec13037b506522719cd9d4ac86484ff51ac/black-25.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175", size = 1742165, upload-time = "2025-09-19T00:34:10.402Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/18/799285282c8236a79f25d590f0222dbd6850e14b060dfaa3e720241fd772/black-25.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f", size = 1581259, upload-time = "2025-09-19T00:32:49.685Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ce/883ec4b6303acdeca93ee06b7622f1fa383c6b3765294824165d49b1a86b/black-25.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831", size = 1655583, upload-time = "2025-09-19T00:30:44.505Z" },
-    { url = "https://files.pythonhosted.org/packages/21/17/5c253aa80a0639ccc427a5c7144534b661505ae2b5a10b77ebe13fa25334/black-25.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357", size = 1343428, upload-time = "2025-09-19T00:32:13.839Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/46/863c90dcd3f9d41b109b7f19032ae0db021f0b2a81482ba0a1e28c84de86/black-25.9.0-py3-none-any.whl", hash = "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae", size = 203363, upload-time = "2025-09-19T00:27:35.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -631,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "gaab-strands-common"
-version = "4.1.6"
+version = "4.1.7"
 source = { editable = "../gaab-strands-common" }
 dependencies = [
     { name = "bedrock-agentcore" },
@@ -660,7 +666,7 @@ dev = [
 
 [[package]]
 name = "gaab-strands-workflow-agent"
-version = "4.1.6"
+version = "4.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aws-opentelemetry-distro" },
@@ -702,7 +708,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=24.0.0" },
+    { name = "black", specifier = ">=26.3.1" },
     { name = "isort", specifier = ">=5.12.0" },
     { name = "moto", specifier = ">=5.0.0" },
     { name = "mypy", specifier = ">=1.8.0" },
@@ -2022,11 +2028,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "0.12.1"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -2415,11 +2421,26 @@ wheels = [
 
 [[package]]
 name = "pytokens"
-version = "0.1.10"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/5f/e959a442435e24f6fb5a01aec6c657079ceaca1b3baf18561c3728d681da/pytokens-0.1.10.tar.gz", hash = "sha256:c9a4bfa0be1d26aebce03e6884ba454e842f186a59ea43a6d3b25af58223c044", size = 12171, upload-time = "2025-02-19T14:51:22.001Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/e5/63bed382f6a7a5ba70e7e132b8b7b8abbcf4888ffa6be4877698dcfbed7d/pytokens-0.1.10-py3-none-any.whl", hash = "sha256:db7b72284e480e69fb085d9f251f66b3d2df8b7166059261258ff35f50fb711b", size = 12046, upload-time = "2025-02-19T14:51:18.694Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]

--- a/source/infrastructure/cdk.json
+++ b/source/infrastructure/cdk.json
@@ -64,7 +64,7 @@
     "@custom-bundler/unit-test": false,
     "solution_id": "SO0276",
     "solution_name": "generative-ai-application-builder-on-aws",
-    "solution_version": "v4.1.6",
+    "solution_version": "v4.1.7",
     "app_registry_name": "GAAB",
     "application_type": "AWS-Solutions",
     "application_trademark_name": "Generative AI Application Builder on AWS",

--- a/source/infrastructure/package-lock.json
+++ b/source/infrastructure/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/gen-ai-app-builder-on-aws-infrastructure",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/gen-ai-app-builder-on-aws-infrastructure",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-solutions-constructs/aws-apigateway-lambda": "^2.74.0",

--- a/source/infrastructure/package.json
+++ b/source/infrastructure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/gen-ai-app-builder-on-aws-infrastructure",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "bin": {
     "infrastructure": "bin/gen-ai-app-builder.js"
   },

--- a/source/infrastructure/test/mock-lambda-func/node-lambda/package-lock.json
+++ b/source/infrastructure/test/mock-lambda-func/node-lambda/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/node-lambda",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/node-lambda",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0"
     }
   }

--- a/source/infrastructure/test/mock-lambda-func/node-lambda/package.json
+++ b/source/infrastructure/test/mock-lambda-func/node-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/node-lambda",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "A mock lambda implementation for CDK infrastructure unit",
   "main": "index.js",
   "scripts": {

--- a/source/infrastructure/test/mock-lambda-func/python-lambda/pyproject.toml
+++ b/source/infrastructure/test/mock-lambda-func/python-lambda/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mock-lambda-function"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Mock lambda implementation to unit test infrastructure code"
 packages = [

--- a/source/infrastructure/test/mock-lambda-func/typescript-lambda/package-lock.json
+++ b/source/infrastructure/test/mock-lambda-func/typescript-lambda/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/mock-typescript-lambda",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/mock-typescript-lambda",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/aws-lambda": "^8.10.138",

--- a/source/infrastructure/test/mock-lambda-func/typescript-lambda/package.json
+++ b/source/infrastructure/test/mock-lambda-func/typescript-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/mock-typescript-lambda",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "A mock lambda implementation for CDK infrastructure unit",
   "main": "index.ts",
   "scripts": {

--- a/source/infrastructure/test/mock-ui/package-lock.json
+++ b/source/infrastructure/test/mock-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/mock-react-app",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/mock-react-app",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/source/infrastructure/test/mock-ui/package.json
+++ b/source/infrastructure/test/mock-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/mock-react-app",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "Mock Reactjs app used for unit testing constructs",
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/source/lambda/agentcore-invocation/poetry.lock
+++ b/source/lambda/agentcore-invocation/poetry.lock
@@ -67,7 +67,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-layer"
-version = "4.1.6"
+version = "4.1.7"
 description = "Layer for AWS Boto3 python SDK"
 optional = false
 python-versions = "^3.13"
@@ -491,7 +491,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "custom-boto3-init"
-version = "4.1.6"
+version = "4.1.7"
 description = "Initialize boto config for AWS Python SDK with custom configuration"
 optional = false
 python-versions = "^3.13"

--- a/source/lambda/agentcore-invocation/pyproject.toml
+++ b/source/lambda/agentcore-invocation/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agent-invocation"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Lambda implementation for agent invocation feature"
 packages = [

--- a/source/lambda/chat/poetry.lock
+++ b/source/lambda/chat/poetry.lock
@@ -97,7 +97,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-layer"
-version = "4.1.6"
+version = "4.1.7"
 description = "Layer for AWS Boto3 python SDK"
 optional = false
 python-versions = "^3.13"
@@ -559,7 +559,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "custom-boto3-init"
-version = "4.1.6"
+version = "4.1.7"
 description = "Initialize boto config for AWS Python SDK with custom configuration"
 optional = false
 python-versions = "^3.13"
@@ -963,7 +963,7 @@ uuid-utils = ">=0.12.0,<1.0"
 
 [[package]]
 name = "langchain-layer"
-version = "4.1.6"
+version = "4.1.7"
 description = "Layer for LangChain libraries"
 optional = false
 python-versions = "^3.13"
@@ -977,9 +977,9 @@ langchain = "^1.2.3"
 langchain-aws = "^1.2.0"
 langchain-classic = "^1.0.1"
 langchain-core = "^1.2.6"
-langgraph = ">=1.0.10"
+langgraph = "^1.0.10"
 numpy = "2.2.2"
-orjson = ">=3.11.6"
+orjson = "^3.11.6"
 pydantic = "2.11.0"
 requests = "2.32.4"
 urllib3 = "2.6.3"

--- a/source/lambda/chat/pyproject.toml
+++ b/source/lambda/chat/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llm-chat-lambda"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Lambda implementation for chat feature"
 packages = [

--- a/source/lambda/custom-authorizer/package-lock.json
+++ b/source/lambda/custom-authorizer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/custom-authorizer",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/custom-authorizer",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-jwt-verify": "^4.0.1",

--- a/source/lambda/custom-authorizer/package.json
+++ b/source/lambda/custom-authorizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/custom-authorizer",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This lambda function is used as a custom REQUEST authorizer for APIs",
   "main": "rest-handler.ts",
   "scripts": {

--- a/source/lambda/custom-resource/poetry.lock
+++ b/source/lambda/custom-resource/poetry.lock
@@ -67,7 +67,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-layer"
-version = "4.1.6"
+version = "4.1.7"
 description = "Layer for AWS Boto3 python SDK"
 optional = false
 python-versions = "^3.13"
@@ -507,7 +507,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "custom-boto3-init"
-version = "4.1.6"
+version = "4.1.7"
 description = "Initialize boto config for AWS Python SDK with custom configuration"
 optional = false
 python-versions = "^3.13"

--- a/source/lambda/custom-resource/pyproject.toml
+++ b/source/lambda/custom-resource/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "custom-resource"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Perform specific operations triggered by AWS CloudFormation events"
 packages = [

--- a/source/lambda/ext-idp-group-mapper/poetry.lock
+++ b/source/lambda/ext-idp-group-mapper/poetry.lock
@@ -67,7 +67,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-layer"
-version = "4.1.6"
+version = "4.1.7"
 description = "Layer for AWS Boto3 python SDK"
 optional = false
 python-versions = "^3.13"
@@ -491,7 +491,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "custom-boto3-init"
-version = "4.1.6"
+version = "4.1.7"
 description = "Initialize boto config for AWS Python SDK with custom configuration"
 optional = false
 python-versions = "^3.13"

--- a/source/lambda/ext-idp-group-mapper/pyproject.toml
+++ b/source/lambda/ext-idp-group-mapper/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ext-idp-group-mapper"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Lambda implementation to change Cognito user groups to External Identity Provider groups in the JWT token"
 packages = [

--- a/source/lambda/feedback-management/package-lock.json
+++ b/source/lambda/feedback-management/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/feedback-management",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/feedback-management",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonpath-plus": "^10.3.0",

--- a/source/lambda/feedback-management/package.json
+++ b/source/lambda/feedback-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/feedback-management",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This lambda supports backs the API to process chat response feedbacks",
   "main": "index.ts",
   "scripts": {

--- a/source/lambda/files-management/package-lock.json
+++ b/source/lambda/files-management/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/files-handler",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/files-handler",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/source/lambda/files-management/package.json
+++ b/source/lambda/files-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/files-handler",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This lambda supports APIs that provide export functionality for use cases",
   "main": "index.ts",
   "scripts": {

--- a/source/lambda/files-metadata-management/package-lock.json
+++ b/source/lambda/files-metadata-management/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/files-metadata",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/files-metadata",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "file-type": "^21.3.2"

--- a/source/lambda/files-metadata-management/package.json
+++ b/source/lambda/files-metadata-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/files-metadata",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This lambda supports APIs that provide export functionality for use cases",
   "main": "index.ts",
   "scripts": {

--- a/source/lambda/invoke-agent/poetry.lock
+++ b/source/lambda/invoke-agent/poetry.lock
@@ -67,7 +67,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-layer"
-version = "4.1.6"
+version = "4.1.7"
 description = "Layer for AWS Boto3 python SDK"
 optional = false
 python-versions = "^3.13"
@@ -491,7 +491,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "custom-boto3-init"
-version = "4.1.6"
+version = "4.1.7"
 description = "Initialize boto config for AWS Python SDK with custom configuration"
 optional = false
 python-versions = "^3.13"

--- a/source/lambda/invoke-agent/pyproject.toml
+++ b/source/lambda/invoke-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "invoke-agent"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Lambda implementation for chat feature"
 packages = [

--- a/source/lambda/layers/aws-node-user-agent-config/package-lock.json
+++ b/source/lambda/layers/aws-node-user-agent-config/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/aws-node-user-agent-config",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/aws-node-user-agent-config",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.11.0",

--- a/source/lambda/layers/aws-node-user-agent-config/package.json
+++ b/source/lambda/layers/aws-node-user-agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/aws-node-user-agent-config",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "AWS Nodejs SDK Config initialization layer",
   "main": "index.js",
   "scripts": {

--- a/source/lambda/layers/aws-sdk-lib/package-lock.json
+++ b/source/lambda/layers/aws-sdk-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/aws-sdk-layer",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/aws-sdk-layer",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.981.0",
@@ -4601,21 +4601,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -4624,7 +4612,23 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -6840,6 +6844,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {

--- a/source/lambda/layers/aws-sdk-lib/package.json
+++ b/source/lambda/layers/aws-sdk-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/aws-sdk-layer",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "AWS Javascript SDK v3 layer",
   "main": "index.js",
   "scripts": {
@@ -38,6 +38,6 @@
     "ts-jest": "^29.4.5"
   },
   "overrides": {
-    "fast-xml-parser": "^5.3.8"
+    "fast-xml-parser": "^5.5.6"
   }
 }

--- a/source/lambda/layers/aws_boto3/pyproject.toml
+++ b/source/lambda/layers/aws_boto3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boto3-layer"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Layer for AWS Boto3 python SDK"
 packages = [

--- a/source/lambda/layers/custom_boto3_init/poetry.lock
+++ b/source/lambda/layers/custom_boto3_init/poetry.lock
@@ -67,7 +67,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-layer"
-version = "4.1.5"
+version = "4.1.7"
 description = "Layer for AWS Boto3 python SDK"
 optional = false
 python-versions = "^3.13"

--- a/source/lambda/layers/custom_boto3_init/pyproject.toml
+++ b/source/lambda/layers/custom_boto3_init/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "custom_boto3_init"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Initialize boto config for AWS Python SDK with custom configuration"
 packages = [

--- a/source/lambda/layers/langchain/pyproject.toml
+++ b/source/lambda/layers/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-layer"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Layer for LangChain libraries"
 packages = [

--- a/source/lambda/model-info/package-lock.json
+++ b/source/lambda/model-info/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/model-info",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/model-info",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/source/lambda/model-info/package.json
+++ b/source/lambda/model-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/model-info",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This lambda supports APIs that provide the capability to deploy GenAI use cases",
   "main": "index.ts",
   "scripts": {

--- a/source/lambda/use-case-details/package-lock.json
+++ b/source/lambda/use-case-details/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/use-case-details",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/use-case-details",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/source/lambda/use-case-details/package.json
+++ b/source/lambda/use-case-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/use-case-details",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This lambda supports APIs that provide details about a deployed use case",
   "main": "index.ts",
   "scripts": {

--- a/source/lambda/use-case-management/package-lock.json
+++ b/source/lambda/use-case-management/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/use-case-management",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/use-case-management",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-jwt-verify": "^5.0.0"

--- a/source/lambda/use-case-management/package.json
+++ b/source/lambda/use-case-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/use-case-management",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This lambda supports APIs that provide the capability to deploy GenAI use cases",
   "main": "index.ts",
   "scripts": {

--- a/source/lambda/websocket-connectors/package-lock.json
+++ b/source/lambda/websocket-connectors/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/websocket-connectors",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/websocket-connectors",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/source/lambda/websocket-connectors/package.json
+++ b/source/lambda/websocket-connectors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/websocket-connectors",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "This lambda function is used to handle connect and disconnect requests",
   "main": "connect-handler.js",
   "scripts": {

--- a/source/scripts/v2_migration/pyproject.toml
+++ b/source/scripts/v2_migration/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gaab-v2-migration"
-version = "4.1.6"
+version = "4.1.7"
 authors = [ "Amazon Web Services" ]
 description = "Migration script to convert v1.X use cases to v2.X"
 packages = [

--- a/source/ui-chat/package-lock.json
+++ b/source/ui-chat/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/gen-ai-app-builder-on-aws-ui-chat",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/gen-ai-app-builder-on-aws-ui-chat",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "dependencies": {
         "@aws-amplify/core": "^6.10.0",
         "@aws-amplify/ui-react": "^6.9.1",
@@ -9316,21 +9316,9 @@
       "peer": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -9339,7 +9327,23 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -12380,6 +12384,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {

--- a/source/ui-chat/package.json
+++ b/source/ui-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/gen-ai-app-builder-on-aws-ui-chat",
   "private": true,
-  "version": "4.1.6",
+  "version": "4.1.7",
   "type": "module",
   "author": {
     "name": "Amazon Web Services",
@@ -83,7 +83,7 @@
   "overrides": {
     "@smithy/config-resolver": "^4.4.6",
     "lodash": "^4.17.23",
-    "fast-xml-parser": "^5.3.8",
+    "fast-xml-parser": "^5.5.6",
     "serialize-javascript": "^7.0.3"
   }
 }

--- a/source/ui-deployment/package-lock.json
+++ b/source/ui-deployment/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/gen-ai-app-builder-on-aws-ui-deployment",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/gen-ai-app-builder-on-aws-ui-deployment",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^5.3.3",
@@ -14755,22 +14755,9 @@
       "peer": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -14780,7 +14767,24 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -18481,6 +18485,22 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {

--- a/source/ui-deployment/package.json
+++ b/source/ui-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/gen-ai-app-builder-on-aws-ui-deployment",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "dependencies": {
     "@aws-amplify/ui-react": "^5.3.3",
     "@aws-sdk/util-arn-parser": "^3.893.0",
@@ -79,7 +79,7 @@
     "url": "https://aws.amazon.com/solutions"
   },
   "overrides": {
-    "fast-xml-parser": "^5.3.8",
+    "fast-xml-parser": "^5.5.6",
     "cookie": "^0.7.2",
     "esbuild": "^0.25.0",
     "@react-native-community/cli": "^17.0.1",


### PR DESCRIPTION
## [4.1.7] - 2026-03-19

### Security

- Upgraded `uv` to `0.10.11` to mitigate [GHSA-6gx3-4362-rf54](https://test.osv.dev/vulnerability/GHSA-6gx3-4362-rf54)
- Upgraded `black` to `26.3.1` to mitigate [CVE-2026-32274](https://nvd.nist.gov/vuln/detail/CVE-2026-32274)
- Upgraded `fast-xml-parser` to `5.5.6` to mitigate [CVE-2026-26278](https://nvd.nist.gov/vuln/detail/CVE-2026-26278)